### PR TITLE
[kube-prometheus-stack] support overriding resource names with those in kse 3.x

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
-  repository: https://prometheus-community.github.io/helm-charts
-  version: 4.24.0
+  repository: file://../kube-state-metrics
+  version: 4.25.0
 - name: prometheus-node-exporter
-  repository: https://prometheus-community.github.io/helm-charts
-  version: 4.8.1
+  repository: file://../prometheus-node-exporter
+  version: 4.14.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 6.48.2
-digest: sha256:0d3ceb56c869c5666de120d6c230eea5eb513b9aaa1f267719efdce351b04868
-generated: "2023-03-21T13:39:58.8305296+08:00"
+digest: sha256:ad3076eef6e2698d465b51a95da0c23fd1c01d304bc9bc88df7f502fb6d9e1eb
+generated: "2023-04-04T18:25:18.0780495+08:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 43.1.4
+version: 43.2.0
 appVersion: 0.61.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -39,12 +39,12 @@ annotations:
 
 dependencies:
   - name: kube-state-metrics
-    version: "4.24.*"
-    repository: https://prometheus-community.github.io/helm-charts
+    version: "4.25.*"
+    repository: file://../kube-state-metrics
     condition: kubeStateMetrics.enabled
   - name: prometheus-node-exporter
-    version: "4.8.*"
-    repository: https://prometheus-community.github.io/helm-charts
+    version: "4.14.*"
+    repository: file://../prometheus-node-exporter
     condition: nodeExporter.enabled
   - name: grafana
     version: "6.48.*"

--- a/charts/kube-prometheus-stack/hack/sync_prometheus_rules.py
+++ b/charts/kube-prometheus-stack/hack/sync_prometheus_rules.py
@@ -199,10 +199,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "%(name)s" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%%s-%%s" (include "kube-prometheus-stack.fullname" .) "%(name)s" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}
@@ -226,7 +233,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: %(name)s
+  {{- else }}
   name: {{ printf "%%s-%%s" (include "kube-prometheus-stack.fullname" .) "%(name)s" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/_helpers.tpl
+++ b/charts/kube-prometheus-stack/templates/_helpers.tpl
@@ -259,3 +259,20 @@ global:
   {{- end }}
 {{- end }}
 {{- end -}}
+
+
+{{/*
+Heritage names of the key resources in KubeSphere 3.x
+*/}}
+{{- define "prometheus-operator.heritageName" -}}
+{{- printf "prometheus-operator" -}}
+{{- end }}
+{{- define "prometheus.heritageName" -}}
+{{- printf "k8s" -}}
+{{- end }}
+{{- define "alertmanager.heritageName" -}}
+{{- printf "main" -}}
+{{- end }}
+{{- define "thanos-ruler.heritageName" -}}
+{{- printf "kubesphere" -}}
+{{- end }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
@@ -2,10 +2,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "alertmanager.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.alertmanager.crname" . }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: alertmanager-{{ include "alertmanager.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-alertmanager
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.alertmanager.annotations }}
   annotations:
@@ -30,13 +38,21 @@ spec:
 {{- end }}
   replicas: {{ .Values.alertmanager.alertmanagerSpec.replicas }}
   listenLocal: {{ .Values.alertmanager.alertmanagerSpec.listenLocal }}
+  {{- if .Values.heritageNameOverride }}
+  serviceAccountName: alertmanager-{{ include "alertmanager.heritageName" . }}
+  {{- else }}
   serviceAccountName: {{ template "kube-prometheus-stack.alertmanager.serviceAccountName" . }}
+  {{- end }}
 {{- if .Values.alertmanager.alertmanagerSpec.externalUrl }}
   externalUrl: "{{ tpl .Values.alertmanager.alertmanagerSpec.externalUrl . }}"
 {{- else if and .Values.alertmanager.ingress.enabled .Values.alertmanager.ingress.hosts }}
   externalUrl: "http://{{ tpl (index .Values.alertmanager.ingress.hosts 0) . }}{{ .Values.alertmanager.alertmanagerSpec.routePrefix }}"
 {{- else }}
+  {{- if .Values.heritageNameOverride }}
+  externalUrl: http://alertmanager-{{ include "alertmanager.heritageName" . }}.{{ template "kube-prometheus-stack.namespace" . }}:{{ .Values.alertmanager.service.port }}
+  {{- else }}
   externalUrl: http://{{ template "kube-prometheus-stack.fullname" . }}-alertmanager.{{ template "kube-prometheus-stack.namespace" . }}:{{ .Values.alertmanager.service.port }}
+  {{- end }}
 {{- end }}
 {{- if .Values.alertmanager.alertmanagerSpec.nodeSelector }}
   nodeSelector:
@@ -109,7 +125,11 @@ spec:
         labelSelector:
           matchExpressions:
             - {key: app.kubernetes.io/name, operator: In, values: [alertmanager]}
+            {{- if .Values.heritageNameOverride }}
+            - {key: alertmanager, operator: In, values: [{{ include "alertmanager.heritageName" . }}]}
+            {{- else }}
             - {key: alertmanager, operator: In, values: [{{ template "kube-prometheus-stack.alertmanager.crname" . }}]}
+            {{- end }}
 {{- else if eq .Values.alertmanager.alertmanagerSpec.podAntiAffinity "soft" }}
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -119,7 +139,11 @@ spec:
           labelSelector:
             matchExpressions:
               - {key: app.kubernetes.io/name, operator: In, values: [alertmanager]}
+              {{- if .Values.heritageNameOverride }}
+              - {key: alertmanager, operator: In, values: [{{ include "alertmanager.heritageName" . }}]}
+              {{- else }}
               - {key: alertmanager, operator: In, values: [{{ template "kube-prometheus-stack.alertmanager.crname" . }}]}
+              {{- end }}
 {{- end }}
 {{- if .Values.alertmanager.alertmanagerSpec.tolerations }}
   tolerations:

--- a/charts/kube-prometheus-stack/templates/alertmanager/extrasecret.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/extrasecret.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.alertmanager.extraSecret.data -}}
 {{- $secretName := printf "alertmanager-%s-extra" (include "kube-prometheus-stack.fullname" . ) -}}
+{{- if .Values.heritageNameOverride }}
+{{- $secretName = printf "alertmanager-%s-extra" (include "alertmanager.heritageName" . ) -}}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,7 +13,11 @@ metadata:
 {{ toYaml .Values.alertmanager.extraSecret.annotations | indent 4 }}
 {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: alertmanager-{{ include "alertmanager.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-alertmanager
+    {{- end }}
     app.kubernetes.io/component: alertmanager
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 data:

--- a/charts/kube-prometheus-stack/templates/alertmanager/ingress.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/ingress.yaml
@@ -6,6 +6,9 @@
 {{- $paths := .Values.alertmanager.ingress.paths | default $routePrefix -}}
 {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
+{{- if .Values.heritageNameOverride }}
+{{- $serviceName = printf "alertmanager-%s" (include "alertmanager.heritageName" . ) -}}
+{{- end }}
 apiVersion: {{ include "kube-prometheus-stack.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -16,7 +19,11 @@ metadata:
 {{ toYaml .Values.alertmanager.ingress.annotations | indent 4 }}
 {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: alertmanager-{{ include "alertmanager.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-alertmanager
+    {{- end }}
 {{- if .Values.alertmanager.ingress.labels }}
 {{ toYaml .Values.alertmanager.ingress.labels | indent 4 }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
@@ -8,17 +8,29 @@
 apiVersion: v1
 kind: List
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: alertmanager-{{ include "alertmanager.heritageName" . }}-ingressperreplica
+  {{- else }}
   name: {{ include "kube-prometheus-stack.fullname" $ }}-alertmanager-ingressperreplica
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 items:
 {{ range $i, $e := until $count }}
   - kind: Ingress
     apiVersion: {{ include "kube-prometheus-stack.ingress.apiVersion" $ }}
     metadata:
+      {{- if .Values.heritageNameOverride }}
+      name: alertmanager-{{ include "alertmanager.heritageName" $ }}-{{ $i }}
+      {{- else }}
       name: {{ include "kube-prometheus-stack.fullname" $ }}-alertmanager-{{ $i }}
+      {{- end }}
       namespace: {{ template "kube-prometheus-stack.namespace" $ }}
       labels:
+        {{- if .Values.heritageNameOverride }}
+        app: alertmanager-{{ include "alertmanager.heritageName" . }}
+        {{- else }}
         app: {{ include "kube-prometheus-stack.name" $ }}-alertmanager
+        {{- end }}
       {{ include "kube-prometheus-stack.labels" $ | indent 8 }}
       {{- if $ingressValues.labels }}
 {{ toYaml $ingressValues.labels | indent 8 }}
@@ -45,11 +57,19 @@ items:
                 backend:
                   {{- if $apiIsStable }}
                   service:
+                    {{- if .Values.heritageNameOverride }}
+                    name: alertmanager-{{ include "alertmanager.heritageName" . }}-{{ $i }}
+                    {{- else }}
                     name: {{ include "kube-prometheus-stack.fullname" $ }}-alertmanager-{{ $i }}
+                    {{- end }}
                     port:
                       number: {{ $servicePort }}
                   {{- else }}
+                  {{- if .Values.heritageNameOverride }}
+                  serviceName: alertmanager-{{ include "alertmanager.heritageName" . }}-{{ $i }}
+                  {{- else }}
                   serviceName: {{ include "kube-prometheus-stack.fullname" $ }}-alertmanager-{{ $i }}
+                  {{- end }}
                   servicePort: {{ $servicePort }}
       {{- end }}
       {{- end -}}

--- a/charts/kube-prometheus-stack/templates/alertmanager/podDisruptionBudget.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/podDisruptionBudget.yaml
@@ -2,10 +2,18 @@
 apiVersion: {{ include "kube-prometheus-stack.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: alertmanager-{{ include "alertmanager.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-alertmanager
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: alertmanager-{{ include "alertmanager.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-alertmanager
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   {{- if .Values.alertmanager.podDisruptionBudget.minAvailable }}
@@ -17,5 +25,9 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: alertmanager
+      {{- if .Values.heritageNameOverride }}
+      alertmanager: {{ include "alertmanager.heritageName" . }}
+      {{- else }}
       alertmanager: {{ template "kube-prometheus-stack.alertmanager.crname" . }}
+      {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/psp-role.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/psp-role.yaml
@@ -3,10 +3,18 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: alertmanager-{{ include "alertmanager.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-alertmanager
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: alertmanager-{{ include "alertmanager.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-alertmanager
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 rules:
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
@@ -18,6 +26,10 @@ rules:
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
+  {{- if .Values.heritageNameOverride }}
+  - alertmanager-{{ include "alertmanager.heritageName" . }}
+  {{- else }}
   - {{ template "kube-prometheus-stack.fullname" . }}-alertmanager
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/psp-rolebinding.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/psp-rolebinding.yaml
@@ -3,18 +3,34 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: alertmanager-{{ include "alertmanager.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-alertmanager
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: alertmanager-{{ include "alertmanager.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-alertmanager
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
+  {{- if .Values.heritageNameOverride }}
+  name: alertmanager-{{ include "alertmanager.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-alertmanager
+  {{- end }}
 subjects:
   - kind: ServiceAccount
+    {{- if .Values.heritageNameOverride }}
+    name: alertmanager-{{ include "alertmanager.heritageName" . }}
+    {{- else }}
     name: {{ template "kube-prometheus-stack.alertmanager.serviceAccountName" . }}
+    {{- end }}
     namespace: {{ template "kube-prometheus-stack.namespace" . }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/psp.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/psp.yaml
@@ -3,9 +3,17 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: alertmanager-{{ include "alertmanager.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-alertmanager
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: alertmanager-{{ include "alertmanager.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-alertmanager
+    {{- end }}
 {{- if .Values.global.rbac.pspAnnotations }}
   annotations:
 {{ toYaml .Values.global.rbac.pspAnnotations | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/secret.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/secret.yaml
@@ -2,14 +2,22 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: alertmanager-{{ include "alertmanager.heritageName" . }}
+  {{- else }}
   name: alertmanager-{{ template "kube-prometheus-stack.alertmanager.crname" . }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 {{- if .Values.alertmanager.secret.annotations }}
   annotations:
 {{ toYaml .Values.alertmanager.secret.annotations | indent 4 }}
 {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: alertmanager-{{ include "alertmanager.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-alertmanager
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 data:
 {{- if .Values.alertmanager.tplConfig }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/service.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/service.yaml
@@ -2,10 +2,18 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: alertmanager-{{ include "alertmanager.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-alertmanager
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: alertmanager-{{ include "alertmanager.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-alertmanager
+    {{- end }}
     self-monitor: {{ .Values.alertmanager.serviceMonitor.selfMonitor | quote }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.alertmanager.service.labels }}
@@ -48,6 +56,10 @@ spec:
 {{- end }}
   selector:
     app.kubernetes.io/name: alertmanager
+    {{- if .Values.heritageNameOverride }}
+    alertmanager: {{ include "alertmanager.heritageName" . }}
+    {{- else }}
     alertmanager: {{ template "kube-prometheus-stack.alertmanager.crname" . }}
+    {{- end }}
   type: "{{ .Values.alertmanager.service.type }}"
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/serviceaccount.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/serviceaccount.yaml
@@ -2,11 +2,20 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: alertmanager-{{ include "alertmanager.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.alertmanager.serviceAccountName" . }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: alertmanager-{{ include "alertmanager.heritageName" . }}
+    app.kubernetes.io/name: alertmanager-{{ include "alertmanager.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-alertmanager
     app.kubernetes.io/name: {{ template "kube-prometheus-stack.name" . }}-alertmanager
+    {{- end }}
     app.kubernetes.io/component: alertmanager
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.alertmanager.serviceAccount.annotations }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/servicemonitor.yaml
@@ -2,15 +2,27 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: alertmanager-{{ include "alertmanager.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-alertmanager
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: alertmanager-{{ include "alertmanager.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-alertmanager
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
+      {{- if .Values.heritageNameOverride }}
+      app: alertmanager-{{ include "alertmanager.heritageName" . }}
+      {{- else }}
       app: {{ template "kube-prometheus-stack.name" . }}-alertmanager
+      {{- end }}
       release: {{ $.Release.Name | quote }}
       self-monitor: "true"
   namespaceSelector:

--- a/charts/kube-prometheus-stack/templates/alertmanager/serviceperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/serviceperreplica.yaml
@@ -4,17 +4,29 @@
 apiVersion: v1
 kind: List
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: alertmanager-{{ include "alertmanager.heritageName" . }}-serviceperreplica
+  {{- else }}
   name: {{ include "kube-prometheus-stack.fullname" $ }}-alertmanager-serviceperreplica
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 items:
 {{- range $i, $e := until $count }}
   - apiVersion: v1
     kind: Service
     metadata:
+      {{- if .Values.heritageNameOverride }}
+      name: alertmanager-{{ include "alertmanager.heritageName" . }}-{{ $i }}
+      {{- else }}
       name: {{ include "kube-prometheus-stack.fullname" $ }}-alertmanager-{{ $i }}
+      {{- end }}
       namespace: {{ template "kube-prometheus-stack.namespace" $ }}
       labels:
+        {{- if .Values.heritageNameOverride }}
+        app: alertmanager-{{ include "alertmanager.heritageName" . }}
+        {{- else }}
         app: {{ include "kube-prometheus-stack.name" $ }}-alertmanager
+        {{- end }}
 {{ include "kube-prometheus-stack.labels" $ | indent 8 }}
       {{- if $serviceValues.annotations }}
       annotations:
@@ -42,8 +54,13 @@ items:
           targetPort: {{ $serviceValues.targetPort }}
       selector:
         app.kubernetes.io/name: alertmanager
+        {{- if .Values.heritageNameOverride }}
+        alertmanager: alertmanager-{{ include "alertmanager.heritageName" $ }}
+        statefulset.kubernetes.io/pod-name: alertmanager-{{ include "alertmanager.heritageName" $ }}-{{ $i }}
+        {{- else }}
         alertmanager: {{ template "kube-prometheus-stack.alertmanager.crname" $ }}
         statefulset.kubernetes.io/pod-name: alertmanager-{{ include "kube-prometheus-stack.alertmanager.crname" $ }}-{{ $i }}
+        {{- end }}
       type: "{{ $serviceValues.type }}"
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/exporters/core-dns/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/core-dns/service.yaml
@@ -1,10 +1,18 @@
-{{- if .Values.coreDns.enabled }}
+{{- if and .Values.coreDns.enabled .Values.coreDns.service.create }}
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: coredns
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-coredns
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    k8s-app: kube-dns
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-coredns
+    {{- end }}
     jobLabel: coredns
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
   namespace: kube-system

--- a/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
@@ -2,10 +2,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: coredns
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-coredns
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: coredns
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-coredns
+    {{- end }}
   {{- with .Values.coreDns.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -15,8 +23,12 @@ spec:
   jobLabel: jobLabel
   selector:
     matchLabels:
+      {{- if .Values.heritageNameOverride }}
+      k8s-app: kube-dns
+      {{- else }}
       app: {{ template "kube-prometheus-stack.name" . }}-coredns
       release: {{ $.Release.Name | quote }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - "kube-system"

--- a/charts/kube-prometheus-stack/templates/exporters/ks-api-server/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/ks-api-server/servicemonitor.yaml
@@ -2,10 +2,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-kubesphere-apiserver
+  {{- if .Values.heritageNameOverride }}
+  name: ks-apiserver
+  {{- else }}
+  name: {{ template "kube-prometheus-stack.fullname" . }}-ks-apiserver
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
-    app: {{ template "kube-prometheus-stack.name" . }}-kubesphere-apiserver
+    {{- if .Values.heritageNameOverride }}
+    app: ks-apiserver
+    {{- else }}
+    app: {{ template "kube-prometheus-stack.name" . }}-ks-apiserver
+    {{- end }}
   {{- with .Values.ksApiServer.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/kube-prometheus-stack/templates/exporters/ks-controller-manager/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/ks-controller-manager/servicemonitor.yaml
@@ -2,10 +2,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-kubesphere-controller-manager
+  {{- if .Values.heritageNameOverride }}
+  name: ks-controller-manager
+  {{- else }}
+  name: {{ template "kube-prometheus-stack.fullname" . }}-ks-controller-manager
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
-    app: {{ template "kube-prometheus-stack.name" . }}-kubesphere-controller-manager
+    {{- if .Values.heritageNameOverride }}
+    app: ks-controller-manager
+    {{- else }}
+    app: {{ template "kube-prometheus-stack.name" . }}-ks-controller-manager
+    {{- end }}
   {{- with .Values.ksControllerManager.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
@@ -2,10 +2,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kube-apiserver
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-apiserver
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: apiserver
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-apiserver
+    {{- end }}
   {{- with .Values.kubeApiServer.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/endpoints.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/endpoints.yaml
@@ -2,9 +2,17 @@
 apiVersion: v1
 kind: Endpoints
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kube-controller-manager-svc
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-controller-manager
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: kube-controller-manager
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-kube-controller-manager
+    {{- end }}
     k8s-app: kube-controller-manager
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
   namespace: kube-system

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/service.yaml
@@ -2,9 +2,17 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kube-controller-manager-svc
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-controller-manager
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: kube-controller-manager
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-kube-controller-manager
+    {{- end }}
     jobLabel: kube-controller-manager
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
   namespace: kube-system

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -2,10 +2,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kube-controller-manager
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-controller-manager
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: kube-controller-manager
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-kube-controller-manager
+    {{- end }}
   {{- with .Values.kubeControllerManager.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -15,8 +23,12 @@ spec:
   jobLabel: jobLabel
   selector:
     matchLabels:
+      {{- if .Values.heritageNameOverride }}
+      app: kube-controller-manager
+      {{- else }}
       app: {{ template "kube-prometheus-stack.name" . }}-kube-controller-manager
       release: {{ $.Release.Name | quote }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - "kube-system"

--- a/charts/kube-prometheus-stack/templates/exporters/kube-etcd/endpoints.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-etcd/endpoints.yaml
@@ -2,9 +2,17 @@
 apiVersion: v1
 kind: Endpoints
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: etcd
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-etcd
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: etcd
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-kube-etcd
+    {{- end }}
     k8s-app: etcd-server
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
   namespace: kube-system

--- a/charts/kube-prometheus-stack/templates/exporters/kube-etcd/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-etcd/service.yaml
@@ -2,10 +2,19 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: etcd
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-etcd
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: etcd
+    jobLabel: etcd
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-kube-etcd
     jobLabel: kube-etcd
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
   namespace: kube-system
 spec:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -2,10 +2,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: etcd
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-etcd
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: etcd
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-kube-etcd
+    {{- end }}
   {{- with .Values.kubeEtcd.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -15,8 +23,12 @@ spec:
   jobLabel: jobLabel
   selector:
     matchLabels:
+      {{- if .Values.heritageNameOverride }}
+      app: etcd
+      {{- else }}
       app: {{ template "kube-prometheus-stack.name" . }}-kube-etcd
       release: {{ $.Release.Name | quote }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - "kube-system"

--- a/charts/kube-prometheus-stack/templates/exporters/kube-proxy/endpoints.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-proxy/endpoints.yaml
@@ -2,9 +2,17 @@
 apiVersion: v1
 kind: Endpoints
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kube-proxy-svc
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-proxy
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: kube-proxy
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-kube-proxy
+    {{- end }}
     k8s-app: kube-proxy
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
   namespace: kube-system

--- a/charts/kube-prometheus-stack/templates/exporters/kube-proxy/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-proxy/service.yaml
@@ -2,9 +2,17 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kube-proxy-svc
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-proxy
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: kube-proxy
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-kube-proxy
+    {{- end }}
     jobLabel: kube-proxy
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
   namespace: kube-system

--- a/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -2,10 +2,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kube-proxy
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-proxy
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: kube-proxy
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-kube-proxy
+    {{- end }}
   {{- with .Values.kubeProxy.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -14,8 +22,12 @@ spec:
   jobLabel: jobLabel
   selector:
     matchLabels:
+      {{- if .Values.heritageNameOverride }}
+      app: kube-proxy
+      {{- else }}
       app: {{ template "kube-prometheus-stack.name" . }}-kube-proxy
       release: {{ $.Release.Name | quote }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - "kube-system"

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/endpoints.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/endpoints.yaml
@@ -2,9 +2,17 @@
 apiVersion: v1
 kind: Endpoints
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kube-scheduler-svc
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-scheduler
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: kube-scheduler
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-kube-scheduler
+    {{- end }}
     k8s-app: kube-scheduler
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
   namespace: kube-system

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/service.yaml
@@ -2,9 +2,17 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kube-scheduler-svc
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-scheduler
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: kube-scheduler
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-kube-scheduler
+    {{- end }}
     jobLabel: kube-scheduler
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
   namespace: kube-system

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -2,10 +2,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kube-scheduler
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-scheduler
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: kube-scheduler
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-kube-scheduler
+    {{- end }}
   {{- with .Values.kubeScheduler.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -15,8 +23,12 @@ spec:
   jobLabel: jobLabel
   selector:
     matchLabels:
+      {{- if .Values.heritageNameOverride }}
+      app: kube-scheduler
+      {{- else }}
       app: {{ template "kube-prometheus-stack.name" . }}-kube-scheduler
       release: {{ $.Release.Name | quote }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - "kube-system"

--- a/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
@@ -2,10 +2,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kubelet
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-kubelet
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: kubelet
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-kubelet
+    {{- end }}
   {{- with .Values.kubelet.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/clusterrole.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/clusterrole.yaml
@@ -2,12 +2,20 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-admission
+  {{- else }}
   name:  {{ template "kube-prometheus-stack.fullname" . }}-admission
+  {{- end }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" $ }}-admission
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" $ }}-admission
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" $ | indent 4 }}
 rules:
   - apiGroups:
@@ -28,6 +36,10 @@ rules:
     resources: ['podsecuritypolicies']
     verbs:     ['use']
     resourceNames:
+    {{- if .Values.heritageNameOverride }}
+    - {{ include "prometheus-operator.heritageName" . }}-admission
+    {{- else }}
     - {{ template "kube-prometheus-stack.fullname" . }}-admission
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -2,19 +2,35 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-admission
+  {{- else }}
   name:  {{ template "kube-prometheus-stack.fullname" . }}-admission
+  {{- end }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" $ }}-admission
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" $ }}-admission
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" $ | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-admission
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-admission
+  {{- end }}
 subjects:
   - kind: ServiceAccount
+    {{- if .Values.heritageNameOverride }}
+    name: {{ include "prometheus-operator.heritageName" . }}-admission
+    {{- else }}
     name: {{ template "kube-prometheus-stack.fullname" . }}-admission
+    {{- end }}
     namespace: {{ template "kube-prometheus-stack.namespace" . }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -2,7 +2,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-admission-create
+  {{- else }}
   name:  {{ template "kube-prometheus-stack.fullname" . }}-admission-create
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
@@ -11,7 +15,11 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}   
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" $ }}-admission-create
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" $ }}-admission-create
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" $ | indent 4 }}
 spec:
   {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
@@ -20,13 +28,21 @@ spec:
   {{- end }}
   template:
     metadata:
+      {{- if .Values.heritageNameOverride }}
+      name: {{ include "prometheus-operator.heritageName" . }}-admission-create
+      {{- else }}
       name:  {{ template "kube-prometheus-stack.fullname" . }}-admission-create
+      {{- end }}
 {{- with .Values.prometheusOperator.admissionWebhooks.patch.podAnnotations }}
       annotations:
 {{ toYaml .  | indent 8 }}
 {{- end }}
       labels:
+        {{- if .Values.heritageNameOverride }}
+        app: {{ include "prometheus-operator.heritageName" $ }}-admission-create
+        {{- else }}
         app: {{ template "kube-prometheus-stack.name" $ }}-admission-create
+        {{- end }}
 {{- include "kube-prometheus-stack.labels" $ | indent 8 }}
     spec:
       {{- if .Values.prometheusOperator.admissionWebhooks.patch.priorityClassName }}
@@ -43,9 +59,17 @@ spec:
           imagePullPolicy: {{ .Values.prometheusOperator.admissionWebhooks.patch.image.pullPolicy }}
           args:
             - create
+            {{- if .Values.heritageNameOverride }}
+            - --host={{ include "prometheus-operator.heritageName" . }},{{ include "prometheus-operator.heritageName" . }}.{{ template "kube-prometheus-stack.namespace" . }}.svc
+            {{- else }}
             - --host={{ template "kube-prometheus-stack.operator.fullname" . }},{{ template "kube-prometheus-stack.operator.fullname" . }}.{{ template "kube-prometheus-stack.namespace" . }}.svc
+            {{- end }}
             - --namespace={{ template "kube-prometheus-stack.namespace" . }}
+            {{- if .Values.heritageNameOverride }}
+            - --secret-name={{ include "prometheus-operator.heritageName" . }}-admission
+            {{- else }}
             - --secret-name={{ template "kube-prometheus-stack.fullname" . }}-admission
+            {{- end }}
           {{- with .Values.prometheusOperator.admissionWebhooks.createSecretJob }}
           securityContext:
           {{ toYaml .securityContext | nindent 12 }}
@@ -53,7 +77,11 @@ spec:
           resources:
 {{ toYaml .Values.prometheusOperator.admissionWebhooks.patch.resources | indent 12 }}
       restartPolicy: OnFailure
+      {{- if .Values.heritageNameOverride }}
+      serviceAccountName: {{ include "prometheus-operator.heritageName" . }}-admission
+      {{- else }}
       serviceAccountName: {{ template "kube-prometheus-stack.fullname" . }}-admission
+      {{- end }}
       {{- with .Values.prometheusOperator.admissionWebhooks.patch.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -2,7 +2,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-admission-patch
+  {{- else }}
   name:  {{ template "kube-prometheus-stack.fullname" . }}-admission-patch
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
@@ -11,7 +15,11 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}   
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" $ }}-admission-patch
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" $ }}-admission-patch
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" $ | indent 4 }}
 spec:
   {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
@@ -20,13 +28,21 @@ spec:
   {{- end }}
   template:
     metadata:
+      {{- if .Values.heritageNameOverride }}
+      name: {{ include "prometheus-operator.heritageName" . }}-admission-patch
+      {{- else }}
       name:  {{ template "kube-prometheus-stack.fullname" . }}-admission-patch
+      {{- end }}
 {{- with .Values.prometheusOperator.admissionWebhooks.patch.podAnnotations }}
       annotations:
 {{ toYaml . | indent 8 }}
 {{- end }}
       labels:
+        {{- if .Values.heritageNameOverride }}
+        app: {{ include "prometheus-operator.heritageName" $ }}-admission-patch
+        {{- else }}
         app: {{ template "kube-prometheus-stack.name" $ }}-admission-patch
+        {{- end }}
 {{- include "kube-prometheus-stack.labels" $ | indent 8 }}
     spec:
       {{- if .Values.prometheusOperator.admissionWebhooks.patch.priorityClassName }}
@@ -43,9 +59,17 @@ spec:
           imagePullPolicy: {{ .Values.prometheusOperator.admissionWebhooks.patch.image.pullPolicy }}
           args:
             - patch
+            {{- if .Values.heritageNameOverride }}
+            - --webhook-name={{ include "prometheus-operator.heritageName" . }}-admission
+            {{- else }}
             - --webhook-name={{ template "kube-prometheus-stack.fullname" . }}-admission
+            {{- end }}
             - --namespace={{ template "kube-prometheus-stack.namespace" . }}
+            {{- if .Values.heritageNameOverride }}
+            - --secret-name={{ include "prometheus-operator.heritageName" . }}-admission
+            {{- else }}
             - --secret-name={{ template "kube-prometheus-stack.fullname" . }}-admission
+            {{- end }}
             - --patch-failure-policy={{ .Values.prometheusOperator.admissionWebhooks.failurePolicy }}
           {{- with .Values.prometheusOperator.admissionWebhooks.patchWebhookJob }}
           securityContext:
@@ -54,7 +78,11 @@ spec:
           resources:
 {{ toYaml .Values.prometheusOperator.admissionWebhooks.patch.resources | indent 12 }}
       restartPolicy: OnFailure
+      {{- if .Values.heritageNameOverride }}
+      serviceAccountName: {{ include "prometheus-operator.heritageName" . }}-admission
+      {{- else }}
       serviceAccountName: {{ template "kube-prometheus-stack.fullname" . }}-admission
+      {{- end }}
       {{- with .Values.prometheusOperator.admissionWebhooks.patch.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/networkpolicy-createSecret.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/networkpolicy-createSecret.yaml
@@ -3,7 +3,11 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-admission-create
+  {{- else }}
   name:  {{ template "kube-prometheus-stack.fullname" . }}-admission-create
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
@@ -14,12 +18,20 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}   
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" $ }}-admission-create
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" $ }}-admission-create
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" $ | indent 4 }}
 spec:
   podSelector:
     matchLabels:
+      {{- if .Values.heritageNameOverride }}
+      app: {{ include "prometheus-operator.heritageName" $ }}-admission-create
+      {{- else }}
       app: {{ template "kube-prometheus-stack.name" $ }}-admission-create
+      {{- end }}
 {{- include "kube-prometheus-stack.labels" $ | indent 6 }}
   egress:
   - {}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/networkpolicy-patchWebhook.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/networkpolicy-patchWebhook.yaml
@@ -3,7 +3,11 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-admission-patch
+  {{- else }}
   name:  {{ template "kube-prometheus-stack.fullname" . }}-admission-patch
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
@@ -14,12 +18,20 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}   
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" $ }}-admission-patch
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" $ }}-admission-patch
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" $ | indent 4 }}
 spec:
   podSelector:
     matchLabels:
+      {{- if .Values.heritageNameOverride }}
+      app: {{ include "prometheus-operator.heritageName" $ }}-admission-patch
+      {{- else }}
       app: {{ template "kube-prometheus-stack.name" $ }}-admission-patch
+      {{- end }}
 {{- include "kube-prometheus-stack.labels" $ | indent 6 }}
   egress:
   - {}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/psp.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/psp.yaml
@@ -2,7 +2,11 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-admission
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-admission
+  {{- end }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -10,7 +14,11 @@ metadata:
 {{ toYaml .Values.global.rbac.pspAnnotations | indent 4 }}
 {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}-admission
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-admission
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   privileged: false

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/role.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/role.yaml
@@ -2,13 +2,21 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-admission
+  {{- else }}
   name:  {{ template "kube-prometheus-stack.fullname" . }}-admission
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" $ }}-admission
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" $ }}-admission
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" $ | indent 4 }}
 rules:
   - apiGroups:

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/rolebinding.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/rolebinding.yaml
@@ -2,20 +2,36 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-admission
+  {{- else }}
   name:  {{ template "kube-prometheus-stack.fullname" . }}-admission
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" $ }}-admission
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" $ }}-admission
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" $ | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-admission
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-admission
+  {{- end }}
 subjects:
   - kind: ServiceAccount
+    {{- if .Values.heritageNameOverride }}
+    name: {{ include "prometheus-operator.heritageName" . }}-admission
+    {{- else }}
     name: {{ template "kube-prometheus-stack.fullname" . }}-admission
+    {{- end }}
     namespace: {{ template "kube-prometheus-stack.namespace" . }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/serviceaccount.yaml
@@ -2,13 +2,21 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-admission
+  {{- else }}
   name:  {{ template "kube-prometheus-stack.fullname" . }}-admission
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" $ }}-admission
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" $ }}-admission
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" $ | indent 4 }}
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -2,14 +2,27 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-admission
+  {{- else }}
   name:  {{ template "kube-prometheus-stack.fullname" . }}-admission
+  {{- end }}
 {{- if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}
   annotations:
+    {{- if .Values.heritageNameOverride }}
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-admission" .Release.Namespace (include "prometheus-operator.heritageName" .) | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s-admission" .Release.Namespace (include "prometheus-operator.heritageName" .) | quote }}
+    {{- else }}
     certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-admission" .Release.Namespace (include "kube-prometheus-stack.fullname" .) | quote }}
     cert-manager.io/inject-ca-from: {{ printf "%s/%s-admission" .Release.Namespace (include "kube-prometheus-stack.fullname" .) | quote }}
+    {{- end }}
 {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}-admission
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" $ }}-admission
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" $ | indent 4 }}
 webhooks:
   - name: prometheusrulemutate.monitoring.coreos.com
@@ -31,7 +44,11 @@ webhooks:
     clientConfig:
       service:
         namespace: {{ template "kube-prometheus-stack.namespace" . }}
+        {{- if .Values.heritageNameOverride }}
+        name: {{ include "prometheus-operator.heritageName" . }}
+        {{- else }}
         name: {{ template "kube-prometheus-stack.operator.fullname" $ }}
+        {{- end }}
         path: /admission-prometheusrules/mutate
       {{- if and .Values.prometheusOperator.admissionWebhooks.caBundle (not .Values.prometheusOperator.admissionWebhooks.patch.enabled) (not .Values.prometheusOperator.admissionWebhooks.certManager.enabled) }}
       caBundle: {{ .Values.prometheusOperator.admissionWebhooks.caBundle }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
@@ -2,14 +2,27 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-admission
+  {{- else }}
   name:  {{ template "kube-prometheus-stack.fullname" . }}-admission
+  {{- end }}
 {{- if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}
   annotations:
+    {{- if .Values.heritageNameOverride }}
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-admission" .Release.Namespace (include "prometheus-operator.heritageName" .) | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s-admission" .Release.Namespace (include "prometheus-operator.heritageName" .) | quote }}
+    {{- else }}
     certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-admission" .Release.Namespace (include "kube-prometheus-stack.fullname" .) | quote }}
     cert-manager.io/inject-ca-from: {{ printf "%s/%s-admission" .Release.Namespace (include "kube-prometheus-stack.fullname" .) | quote }}
+    {{- end }}
 {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}-admission
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" $ }}-admission
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" $ | indent 4 }}
 webhooks:
   - name: prometheusrulemutate.monitoring.coreos.com
@@ -31,7 +44,11 @@ webhooks:
     clientConfig:
       service:
         namespace: {{ template "kube-prometheus-stack.namespace" . }}
+        {{- if .Values.heritageNameOverride }}
+        name: {{ include "prometheus-operator.heritageName" . }}
+        {{- else }}
         name: {{ template "kube-prometheus-stack.operator.fullname" $ }}
+        {{- end }}
         path: /admission-prometheusrules/validate
       {{- if and .Values.prometheusOperator.admissionWebhooks.caBundle (not .Values.prometheusOperator.admissionWebhooks.patch.enabled) (not .Values.prometheusOperator.admissionWebhooks.certManager.enabled) }}
       caBundle: {{ .Values.prometheusOperator.admissionWebhooks.caBundle }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/aggregate-clusterroles.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/aggregate-clusterroles.yaml
@@ -3,12 +3,20 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-prometheus-crd-view
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus-crd-view
+  {{- end }}
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-operator
+    {{- end }}
     {{- include "kube-prometheus-stack.labels" . | nindent 4 }}
 rules:
 - apiGroups: ["monitoring.coreos.com"]
@@ -18,11 +26,19 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-prometheus-crd-edit
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus-crd-edit
+  {{- end }}
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-operator
+    {{- end }}
     {{- include "kube-prometheus-stack.labels" . | nindent 4 }}
 rules:
 - apiGroups: ["monitoring.coreos.com"]

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/certmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/certmanager.yaml
@@ -5,7 +5,11 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-self-signed-issuer
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-self-signed-issuer
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 spec:
   selfSigned: {}
@@ -14,13 +18,25 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-root-cert
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-root-cert
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 spec:
+  {{- if .Values.heritageNameOverride }}
+  secretName: {{ include "prometheus-operator.heritageName" . }}-root-cert
+  {{- else }}
   secretName: {{ template "kube-prometheus-stack.fullname" . }}-root-cert
+  {{- end }}
   duration: {{ .Values.prometheusOperator.admissionWebhooks.certManager.rootCert.duration | default "43800h0m0s" | quote }}
   issuerRef:
+    {{- if .Values.heritageNameOverride }}
+    name: {{ include "prometheus-operator.heritageName" . }}-self-signed-issuer
+    {{- else }}
     name: {{ template "kube-prometheus-stack.fullname" . }}-self-signed-issuer
+    {{- end }}
   commonName: "ca.webhook.kube-prometheus-stack"
   isCA: true
 ---
@@ -28,30 +44,56 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-root-issuer
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-root-issuer
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 spec:
   ca:
+    {{- if .Values.heritageNameOverride }}
+    secretName: {{ include "prometheus-operator.heritageName" . }}-root-cert
+    {{- else }}
     secretName: {{ template "kube-prometheus-stack.fullname" . }}-root-cert
+    {{- end }}
 {{- end }}
 ---
 # generate a server certificate for the apiservices to use
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-admission
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-admission
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 spec:
+  {{- if .Values.heritageNameOverride }}
+  secretName: {{ include "prometheus-operator.heritageName" . }}-admission
+  {{- else }}
   secretName: {{ template "kube-prometheus-stack.fullname" . }}-admission
+  {{- end }}
   duration: {{ .Values.prometheusOperator.admissionWebhooks.certManager.admissionCert.duration | default "8760h0m0s" | quote }}
   issuerRef:
     {{- if .Values.prometheusOperator.admissionWebhooks.certManager.issuerRef }}
     {{- toYaml .Values.prometheusOperator.admissionWebhooks.certManager.issuerRef | nindent 4 }}
     {{- else }}
+    {{- if .Values.heritageNameOverride }}
+    name: {{ include "prometheus-operator.heritageName" . }}-root-issuer
+    {{- else }}
     name: {{ template "kube-prometheus-stack.fullname" . }}-root-issuer
     {{- end }}
+    {{- end }}
   dnsNames:
+  {{- if .Values.heritageNameOverride }}
   - {{ template "kube-prometheus-stack.operator.fullname" . }}
   - {{ template "kube-prometheus-stack.operator.fullname" . }}.{{ template "kube-prometheus-stack.namespace" . }}
   - {{ template "kube-prometheus-stack.operator.fullname" . }}.{{ template "kube-prometheus-stack.namespace" . }}.svc
+  {{- else }}
+  - {{ include "prometheus-operator.heritageName" . }}
+  - {{ include "prometheus-operator.heritageName" . }}.{{ template "kube-prometheus-stack.namespace" . }}
+  - {{ include "prometheus-operator.heritageName" . }}.{{ template "kube-prometheus-stack.namespace" . }}.svc
+  {{- end }}
 {{- end -}}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/clusterrole.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/clusterrole.yaml
@@ -2,9 +2,17 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kubesphere-{{ include "prometheus-operator.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-operator
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 rules:
 - apiGroups:

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/clusterrolebinding.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/clusterrolebinding.yaml
@@ -2,16 +2,32 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kubesphere-{{ include "prometheus-operator.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-operator
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+  {{- if .Values.heritageNameOverride }}
+  name: kubesphere-{{ include "prometheus-operator.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  {{- end }}
 subjects:
 - kind: ServiceAccount
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.operator.serviceAccountName" . }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -4,10 +4,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-operator
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.prometheusOperator.labels }}
 {{ toYaml .Values.prometheusOperator.labels | indent 4 }}
@@ -20,12 +28,20 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      {{- if .Values.heritageNameOverride }}
+      app: {{ include "prometheus-operator.heritageName" . }}
+      {{- else }}
       app: {{ template "kube-prometheus-stack.name" . }}-operator
+      {{- end }}
       release: {{ $.Release.Name | quote }}
   template:
     metadata:
       labels:
+        {{- if .Values.heritageNameOverride }}
+        app: {{ include "prometheus-operator.heritageName" . }}
+        {{- else }}
         app: {{ template "kube-prometheus-stack.name" . }}-operator
+        {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 8 }}
 {{- if .Values.prometheusOperator.podLabels }}
 {{ toYaml .Values.prometheusOperator.podLabels | indent 8 }}
@@ -39,7 +55,11 @@ spec:
       priorityClassName: {{ .Values.prometheusOperator.priorityClassName }}
     {{- end }}
       containers:
+        {{- if .Values.heritageNameOverride }}
+        - name: {{ include "prometheus-operator.heritageName" . }}
+        {{- else }}
         - name: {{ template "kube-prometheus-stack.name" . }}
+        {{- end }}
           {{- $registry := .Values.global.imageRegistry | default .Values.prometheusOperator.image.registry -}}
           {{- if .Values.prometheusOperator.image.sha }}
           image: "{{ $registry }}/{{ .Values.prometheusOperator.image.repository }}:{{ .Values.prometheusOperator.image.tag }}@sha256:{{ .Values.prometheusOperator.image.sha }}"
@@ -138,7 +158,11 @@ spec:
         - name: tls-secret
           secret:
             defaultMode: 420
+            {{- if .Values.heritageNameOverride }}
+            secretName: {{ include "prometheus-operator.heritageName" . }}-admission
+            {{- else }}
             secretName: {{ template "kube-prometheus-stack.fullname" . }}-admission
+            {{- end }}
 {{- end }}
     {{- with .Values.prometheusOperator.dnsConfig }}
       dnsConfig:
@@ -148,7 +172,11 @@ spec:
       securityContext:
 {{ toYaml .Values.prometheusOperator.securityContext | indent 8 }}
 {{- end }}
+      {{- if .Values.heritageNameOverride }}
+      serviceAccountName: {{ include "prometheus-operator.heritageName" . }}
+      {{- else }}
       serviceAccountName: {{ template "kube-prometheus-stack.operator.serviceAccountName" . }}
+      {{- end }}
 {{- if .Values.prometheusOperator.hostNetwork }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/networkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/networkpolicy.yaml
@@ -2,10 +2,18 @@
 apiVersion: {{ template "kube-prometheus-stack.prometheus.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-operator
+    {{- end }}
 spec:
   egress: 
     - {}
@@ -21,6 +29,10 @@ spec:
     - Ingress
   podSelector:
     matchLabels:
+      {{- if .Values.heritageNameOverride }}
+      app: {{ include "prometheus-operator.heritageName" . }}
+      {{- else }}
       app: {{ template "kube-prometheus-stack.name" . }}-operator
+      {{- end }}
       release: {{ $.Release.Name | quote }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/psp-clusterrole.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/psp-clusterrole.yaml
@@ -3,9 +3,17 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-psp
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-operator-psp
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-operator
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 rules:
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
@@ -17,6 +25,10 @@ rules:
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
+  {{- if .Values.heritageNameOverride }}
+  - {{ include "prometheus-operator.heritageName" . }}
+  {{- else }}
   - {{ template "kube-prometheus-stack.fullname" . }}-operator
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/psp-clusterrolebinding.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/psp-clusterrolebinding.yaml
@@ -3,17 +3,33 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-psp
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-operator-psp
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-operator
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}-psp
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-operator-psp
+  {{- end }}
 subjects:
   - kind: ServiceAccount
+    {{- if .Values.heritageNameOverride }}
+    name: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     name: {{ template "kube-prometheus-stack.operator.serviceAccountName" . }}
+    {{- end }}
     namespace: {{ template "kube-prometheus-stack.namespace" . }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/psp.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/psp.yaml
@@ -3,9 +3,17 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-operator
+    {{- end }}
 {{- if .Values.global.rbac.pspAnnotations }}
   annotations:
 {{ toYaml .Values.global.rbac.pspAnnotations | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/service.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/service.yaml
@@ -2,10 +2,18 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-operator
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.prometheusOperator.service.labels }}
 {{ toYaml .Values.prometheusOperator.service.labels | indent 4 }}
@@ -52,7 +60,11 @@ spec:
     targetPort: https
   {{- end }}
   selector:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-operator
+    {{- end }}
     release: {{ $.Release.Name | quote }}
   type: "{{ .Values.prometheusOperator.service.type }}"
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/serviceaccount.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/serviceaccount.yaml
@@ -2,11 +2,23 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.operator.serviceAccountName" . }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-operator
+    {{- end }}
+    {{- if .Values.heritageNameOverride }}
+    app.kubernetes.io/name: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     app.kubernetes.io/name: {{ template "kube-prometheus-stack.name" . }}-prometheus-operator
+    {{- end }}
     app.kubernetes.io/component: prometheus-operator
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.global.imagePullSecrets }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/servicemonitor.yaml
@@ -2,10 +2,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-operator
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- include "kubesphere-monitor.labels" . | indent 4 }}
 spec:
@@ -14,10 +22,18 @@ spec:
   - port: https
     scheme: https
     tlsConfig:
+      {{- if .Values.heritageNameOverride }}
+      serverName: {{ include "prometheus-operator.heritageName" . }}
+      {{- else }}
       serverName: {{ template "kube-prometheus-stack.operator.fullname" . }}
+      {{- end }}
       ca:
         secret:
+          {{- if .Values.heritageNameOverride }}
+          name: {{ include "prometheus-operator.heritageName" . }}-admission
+          {{- else }}
           name: {{ template "kube-prometheus-stack.fullname" . }}-admission
+          {{- end }}
           key: {{ if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}ca.crt{{ else }}ca{{ end }}
           optional: false
   {{- else }}
@@ -37,7 +53,11 @@ spec:
 {{- end }}
   selector:
     matchLabels:
+      {{- if .Values.heritageNameOverride }}
+      app: {{ include "prometheus-operator.heritageName" . }}
+      {{- else }}
       app: {{ template "kube-prometheus-stack.name" . }}-operator
+      {{- end }}
       release: {{ $.Release.Name | quote }}
   namespaceSelector:
     matchNames:

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/verticalpodautoscaler.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/verticalpodautoscaler.yaml
@@ -2,10 +2,18 @@
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus-operator.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-operator
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   resourcePolicy:
@@ -25,7 +33,11 @@ spec:
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
+    {{- if .Values.heritageNameOverride }}
+    name: {{ include "prometheus-operator.heritageName" . }}
+    {{- else }}
     name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+    {{- end }}
   {{- if .Values.prometheusOperator.verticalPodAutoscaler.updatePolicy }}
   updatePolicy:
     {{- if .Values.prometheusOperator.verticalPodAutoscaler.updatePolicy.updateMode }}

--- a/charts/kube-prometheus-stack/templates/prometheus/additionalAlertRelabelConfigs.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/additionalAlertRelabelConfigs.yaml
@@ -2,14 +2,22 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}-am-relabel-config
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus-am-relabel-confg
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 {{- if .Values.prometheus.prometheusSpec.additionalPrometheusSecretsAnnotations }}
   annotations:
 {{ toYaml .Values.prometheus.prometheusSpec.additionalPrometheusSecretsAnnotations | indent 4 }}
 {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    name: prometheus-{{ include "prometheus.heritageName" . }}-am-relabel-config
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus-am-relabel-confg
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 data:
   additional-alert-relabel-configs.yaml: {{ toYaml .Values.prometheus.prometheusSpec.additionalAlertRelabelConfigs | b64enc | quote }}

--- a/charts/kube-prometheus-stack/templates/prometheus/additionalAlertmanagerConfigs.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/additionalAlertmanagerConfigs.yaml
@@ -2,14 +2,22 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}-am-config
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus-am-confg
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 {{- if .Values.prometheus.prometheusSpec.additionalPrometheusSecretsAnnotations }}
   annotations:
 {{ toYaml .Values.prometheus.prometheusSpec.additionalPrometheusSecretsAnnotations | indent 4 }}
 {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}-am-config
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus-am-confg
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 data:
   additional-alertmanager-configs.yaml: {{ tpl (toYaml .Values.prometheus.prometheusSpec.additionalAlertManagerConfigs) . | b64enc | quote }}

--- a/charts/kube-prometheus-stack/templates/prometheus/additionalPrometheusRules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/additionalPrometheusRules.yaml
@@ -2,7 +2,11 @@
 apiVersion: v1
 kind: List
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" $ }}-additional-prometheus-rules
+  {{- else }}
   name: {{ include "kube-prometheus-stack.fullname" $ }}-additional-prometheus-rules
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 items:
 {{- if .Values.additionalPrometheusRulesMap }}
@@ -10,10 +14,18 @@ items:
   - apiVersion: monitoring.coreos.com/v1
     kind: PrometheusRule
     metadata:
+      {{- if .Values.heritageNameOverride }}
+      name: prometheus-{{ include "prometheus.heritageName" $ }}-{{ $prometheusRuleName }}
+      {{- else }}
       name: {{ template "kube-prometheus-stack.name" $ }}-{{ $prometheusRuleName }}
+      {{- end }}
       namespace: {{ template "kube-prometheus-stack.namespace" $ }}
       labels:
+        {{- if .Values.heritageNameOverride }}
+        name: prometheus-{{ include "prometheus.heritageName" $ }}
+        {{- else }}
         app: {{ template "kube-prometheus-stack.name" $ }}
+        {{- end }}
 {{ include "kube-prometheus-stack.labels" $ | indent 8 }}
     {{- if $prometheusRule.additionalLabels }}
 {{ toYaml $prometheusRule.additionalLabels | indent 8 }}
@@ -30,7 +42,11 @@ items:
       name: {{ template "kube-prometheus-stack.name" $ }}-{{ .name }}
       namespace: {{ template "kube-prometheus-stack.namespace" $ }}
       labels:
+        {{- if .Values.heritageNameOverride }}
+        app: prometheus-{{ include "prometheus.heritageName" $ }}
+        {{- else }}
         app: {{ template "kube-prometheus-stack.name" $ }}
+        {{- end }}
 {{ include "kube-prometheus-stack.labels" $ | indent 8 }}
     {{- if .additionalLabels }}
 {{ toYaml .additionalLabels | indent 8 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/additionalScrapeConfigs.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/additionalScrapeConfigs.yaml
@@ -2,14 +2,22 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus-scrape-confg
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}-scrape-confg
+  {{- else }}
+  name: {{ template "kube-prometheus-stack.fullname" . }}-scrape-confg
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 {{- if .Values.prometheus.prometheusSpec.additionalPrometheusSecretsAnnotations }}
   annotations:
 {{ toYaml .Values.prometheus.prometheusSpec.additionalPrometheusSecretsAnnotations | indent 4 }}
 {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    name: prometheus-{{ include "prometheus.heritageName" . }}-scrape-confg
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus-scrape-confg
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 data:
 {{- if  eq ( typeOf .Values.prometheus.prometheusSpec.additionalScrapeConfigs ) "string" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/clusterrole.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/clusterrole.yaml
@@ -2,9 +2,17 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kubesphere-prometheus-{{ include "prometheus.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 rules:
 # This permission are not in the kube-prometheus repo

--- a/charts/kube-prometheus-stack/templates/prometheus/clusterrolebinding.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/clusterrolebinding.yaml
@@ -2,17 +2,33 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kubesphere-prometheus-{{ include "prometheus.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+  {{- if .Values.heritageNameOverride }}
+  name: kubesphere-prometheus-{{ include "prometheus.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
+  {{- end }}
 subjects:
   - kind: ServiceAccount
+    {{- if .Values.heritageNameOverride }}
+    name: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     name: {{ template "kube-prometheus-stack.prometheus.serviceAccountName" . }}
+    {{- end }}
     namespace: {{ template "kube-prometheus-stack.namespace" . }}
 {{- end }}
 

--- a/charts/kube-prometheus-stack/templates/prometheus/csi-secret.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/csi-secret.yaml
@@ -3,10 +3,18 @@
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- end }}
 spec:
 {{ toYaml .Values.prometheus.prometheusSpec.thanos.secretProviderClass | indent 2 }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/extrasecret.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/extrasecret.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.prometheus.extraSecret.data -}}
 {{- $secretName := printf "prometheus-%s-extra" (include "kube-prometheus-stack.fullname" . ) -}}
+{{- if .Values.heritageNameOverride }}
+{{- $secretName = printf "prometheus-%s-extra" (include "prometheus.heritageName" . ) -}}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,7 +13,11 @@ metadata:
 {{ toYaml .Values.prometheus.extraSecret.annotations | indent 4 }}
 {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- end }}
     app.kubernetes.io/component: prometheus
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 data:

--- a/charts/kube-prometheus-stack/templates/prometheus/ingress.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingress.yaml
@@ -6,6 +6,9 @@
   {{- $paths := .Values.prometheus.ingress.paths | default $routePrefix -}}
   {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
   {{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
+  {{- if .Values.heritageNameOverride }}
+  {{- $serviceName = printf "prometheus-%s" (include "prometheus.heritageName" .) -}}
+  {{- end }}
 apiVersion: {{ include "kube-prometheus-stack.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -16,7 +19,11 @@ metadata:
   name: {{ $serviceName }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.prometheus.ingress.labels }}
 {{ toYaml .Values.prometheus.ingress.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
@@ -6,6 +6,9 @@
 {{- $paths := .Values.prometheus.thanosIngress.paths | default $routePrefix -}}
 {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
+{{- if .Values.heritageNameOverride }}
+{{- $serviceName = printf "prometheus-%s" (include "prometheus.heritageName" .) -}}
+{{- end }}
 apiVersion: {{ include "kube-prometheus-stack.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -13,9 +16,17 @@ metadata:
   annotations:
 {{ toYaml .Values.prometheus.thanosIngress.annotations | indent 4 }}
 {{- end }}
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}-thanos-gateway
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-thanos-gateway
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.prometheus.thanosIngress.labels }}
 {{ toYaml .Values.prometheus.thanosIngress.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
@@ -8,17 +8,29 @@
 apiVersion: v1
 kind: List
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}-ingressperreplica
+  {{- else }}
   name: {{ include "kube-prometheus-stack.fullname" $ }}-prometheus-ingressperreplica
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" $ }}
 items:
 {{ range $i, $e := until $count }}
   - kind: Ingress
     apiVersion: {{ include "kube-prometheus-stack.ingress.apiVersion" $ }}
     metadata:
+      {{- if .Values.heritageNameOverride }}
+      name: prometheus-{{ include "prometheus.heritageName" $ }}-{{ $i }}
+      {{- else }}
       name: {{ include "kube-prometheus-stack.fullname" $ }}-prometheus-{{ $i }}
+      {{- end }}
       namespace: {{ template "kube-prometheus-stack.namespace" $ }}
       labels:
+        {{- if .Values.heritageNameOverride }}
+        app: prometheus-{{ include "prometheus.heritageName" $ }}
+        {{- else }}
         app: {{ include "kube-prometheus-stack.name" $ }}-prometheus
+        {{- end }}
       {{ include "kube-prometheus-stack.labels" $ | indent 8 }}
       {{- if $ingressValues.labels }}
 {{ toYaml $ingressValues.labels | indent 8 }}
@@ -45,11 +57,19 @@ items:
                 backend:
                   {{- if $apiIsStable }}
                   service:
+                    {{- if .Values.heritageNameOverride }}
+                    name: prometheus-{{ include "prometheus.heritageName" $ }}-{{ $i }}
+                    {{- else }}
                     name: {{ include "kube-prometheus-stack.fullname" $ }}-prometheus-{{ $i }}
+                    {{- end }}
                     port:
                       number: {{ $servicePort }}
                   {{- else }}
+                  {{- if .Values.heritageNameOverride }}
+                  serviceName: prometheus-{{ include "prometheus.heritageName" . }}-{{ $i }}
+                  {{- else }}
                   serviceName: {{ include "kube-prometheus-stack.fullname" $ }}-prometheus-{{ $i }}
+                  {{- end }}
                   servicePort: {{ $servicePort }}
       {{- end }}
       {{- end -}}

--- a/charts/kube-prometheus-stack/templates/prometheus/podDisruptionBudget.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/podDisruptionBudget.yaml
@@ -2,10 +2,18 @@
 apiVersion: {{ include "kube-prometheus-stack.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   {{- if .Values.prometheus.podDisruptionBudget.minAvailable }}
@@ -17,5 +25,9 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: prometheus
+      {{- if .Values.heritageNameOverride }}
+      prometheus: {{ include "prometheus.heritageName" . }}
+      {{- else }}
       prometheus: {{ template "kube-prometheus-stack.prometheus.crname" . }}
+      {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/podmonitors.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/podmonitors.yaml
@@ -9,7 +9,11 @@ items:
       name: {{ .name }}
       namespace: {{ template "kube-prometheus-stack.namespace" $ }}
       labels:
+        {{- if .Values.heritageNameOverride }}
+        app: prometheus-{{ include "prometheus.heritageName" $ }}
+        {{- else }}
         app: {{ template "kube-prometheus-stack.name" $ }}-prometheus
+        {{- end }}
 {{ include "kube-prometheus-stack.labels" $ | indent 8 }}
         {{- if .additionalLabels }}
 {{ toYaml .additionalLabels | indent 8 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -2,10 +2,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "prometheus.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.prometheus.crname" . }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.prometheus.annotations }}
   annotations:
@@ -19,7 +27,11 @@ spec:
 {{ toYaml .Values.prometheus.prometheusSpec.alertingEndpoints | indent 6 }}
 {{- else if .Values.alertmanager.enabled }}
       - namespace: {{ template "kube-prometheus-stack.namespace" . }}
+        {{- if .Values.heritageNameOverride }}
+        name: alertmanager-{{ include "alertmanager.heritageName" . }}
+        {{- else }}
         name: {{ template "kube-prometheus-stack.fullname" . }}-alertmanager
+        {{- end }}
         port: {{ .Values.alertmanager.alertmanagerSpec.portName }}
         {{- if .Values.alertmanager.alertmanagerSpec.routePrefix }}
         pathPrefix: "{{ .Values.alertmanager.alertmanagerSpec.routePrefix }}"
@@ -73,7 +85,11 @@ spec:
 {{- else if and .Values.prometheus.ingress.enabled .Values.prometheus.ingress.hosts }}
   externalUrl: "http://{{ tpl (index .Values.prometheus.ingress.hosts 0) . }}{{ .Values.prometheus.prometheusSpec.routePrefix }}"
 {{- else }}
+  {{- if .Values.heritageNameOverride }}
+  externalUrl: http://prometheus-{{ include "prometheus.heritageName" . }}.{{ template "kube-prometheus-stack.namespace" . }}:{{ .Values.prometheus.service.port }}
+  {{- else }}
   externalUrl: http://{{ template "kube-prometheus-stack.fullname" . }}-prometheus.{{ template "kube-prometheus-stack.namespace" . }}:{{ .Values.prometheus.service.port }}
+  {{- end }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.nodeSelector }}
   nodeSelector:
@@ -133,7 +149,11 @@ spec:
   configMaps:
 {{ toYaml .Values.prometheus.prometheusSpec.configMaps | indent 4 }}
 {{- end }}
+  {{- if .Values.heritageNameOverride }}
+  serviceAccountName: prometheus-{{ include "prometheus.heritageName" . }}
+  {{- else }}
   serviceAccountName: {{ template "kube-prometheus-stack.prometheus.serviceAccountName" . }}
+  {{- end }}
 {{- if .Values.prometheus.prometheusSpec.serviceMonitorSelector }}
   serviceMonitorSelector:
 {{ toYaml .Values.prometheus.prometheusSpec.serviceMonitorSelector | indent 4 }}
@@ -218,6 +238,9 @@ spec:
   ruleSelector:
     matchLabels:
       release: {{ $.Release.Name | quote }}
+      {{- if .Values.heritageNameOverride }}
+      prometheus: {{ include "prometheus.heritageName" . }}
+      {{- end }}
 {{ else }}
   ruleSelector: {}
 {{- end }}
@@ -246,7 +269,11 @@ spec:
         labelSelector:
           matchExpressions:
             - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
+            {{- if .Values.heritageNameOverride }}
+            - {key: prometheus, operator: In, values: [{{ include "prometheus.heritageName" . }}]}
+            {{- else }}
             - {key: prometheus, operator: In, values: [{{ template "kube-prometheus-stack.prometheus.crname" . }}]}
+            {{- end }}
 {{- else if eq .Values.prometheus.prometheusSpec.podAntiAffinity "soft" }}
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -256,7 +283,11 @@ spec:
           labelSelector:
             matchExpressions:
               - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
+              {{- if .Values.heritageNameOverride }}
+              - {key: prometheus, operator: In, values: [{{ include "prometheus.heritageName" . }}]}
+              {{- else }}
               - {key: prometheus, operator: In, values: [{{ template "kube-prometheus-stack.prometheus.crname" . }}]}
+              {{- end }}
 {{- end }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.tolerations }}
@@ -273,7 +304,11 @@ spec:
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.additionalScrapeConfigs }}
   additionalScrapeConfigs:
+    {{- if .Values.heritageNameOverride }}
+    name: prometheus-{{ include "prometheus.heritageName" . }}-scrape-config
+    {{- else }}
     name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus-scrape-confg
+    {{- end }}
     key: additional-scrape-configs.yaml
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.additionalScrapeConfigsSecret.enabled }}
@@ -284,7 +319,11 @@ spec:
 {{- if or .Values.prometheus.prometheusSpec.additionalAlertManagerConfigs .Values.prometheus.prometheusSpec.additionalAlertManagerConfigsSecret }}
   additionalAlertManagerConfigs:
 {{- if .Values.prometheus.prometheusSpec.additionalAlertManagerConfigs }}
+    {{- if .Values.heritageNameOverride }}
+    name: prometheus-{{ include "prometheus.heritageName" . }}-am-config
+    {{- else }}
     name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus-am-confg
+    {{- end }}
     key: additional-alertmanager-configs.yaml
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.additionalAlertManagerConfigsSecret }}

--- a/charts/kube-prometheus-stack/templates/prometheus/psp-clusterrole.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/psp-clusterrole.yaml
@@ -3,9 +3,17 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}-psp
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus-psp
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 rules:
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
@@ -17,6 +25,10 @@ rules:
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
+  {{- if .Values.heritageNameOverride }}
+  - prometheus-{{ include "prometheus.heritageName" . }}
+  {{- else }}
   - {{ template "kube-prometheus-stack.fullname" . }}-prometheus
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/psp-clusterrolebinding.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/psp-clusterrolebinding.yaml
@@ -3,17 +3,33 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}-psp
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus-psp
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}-psp
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus-psp
+  {{- end }}
 subjects:
   - kind: ServiceAccount
+    {{- if .Values.heritageNameOverride }}
+    name: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     name: {{ template "kube-prometheus-stack.prometheus.serviceAccountName" . }}
+    {{- end }}
     namespace: {{ template "kube-prometheus-stack.namespace" . }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/psp.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/psp.yaml
@@ -3,9 +3,17 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- end }}
 {{- if .Values.global.rbac.pspAnnotations }}
   annotations:
 {{ toYaml .Values.global.rbac.pspAnnotations | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/roleBindingConfig.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/roleBindingConfig.yaml
@@ -2,16 +2,32 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
+  {{- end }}
 subjects:
   - kind: ServiceAccount
+    {{- if .Values.heritageNameOverride }}
+    name: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     name: {{ template "kube-prometheus-stack.prometheus.serviceAccountName" . }}
+    {{- end }}
     namespace: {{ template "kube-prometheus-stack.namespace" . }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/roleConfig.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/roleConfig.yaml
@@ -2,9 +2,17 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
+  {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 rules:
   # This permission are not in the kube-prometheus repo

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/alertmanager-rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/alertmanager-rules.yaml
@@ -10,7 +10,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: alertmanager-rules
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "alertmanager-rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/apiserver.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/apiserver.rules.yaml
@@ -8,10 +8,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "apiserver.rules" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "apiserver.rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/cluster.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/cluster.rules.yaml
@@ -8,10 +8,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "cluster.rules" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "cluster.rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/config-reloaders.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/config-reloaders.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: config-reloaders
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "config-reloaders" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/controller_manager.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/controller_manager.rules.yaml
@@ -8,10 +8,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "controller_manager.rules" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "controller_manager.rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/coredns.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/coredns.rules.yaml
@@ -8,10 +8,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "coredns.rules" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "coredns.rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/etcd.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/etcd.rules.yaml
@@ -8,10 +8,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "etcd.rules" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "etcd.rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/etcd.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/etcd.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: etcd
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "etcd" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/etcd_histogram.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/etcd_histogram.rules.yaml
@@ -8,10 +8,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "etcd_histogram.rules" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "etcd_histogram.rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general-rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general-rules.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: general-rules
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "general-rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"
@@ -84,7 +88,7 @@ spec:
         '
       runbook_url: {{ .Values.defaultRules.runbookUrl }}/general/infoinhibitor
       summary: Info-level alert inhibition.
-    expr: ALERTS{severity = "info"} == 1 unless on(namespace) ALERTS{alertname != "InfoInhibitor", severity =~ "warning|critical", alertstate="firing"} == 1
+    expr: ALERTS{severity = "info"} == 1 unless on(namespace, cluster) ALERTS{alertname != "InfoInhibitor", severity =~ "warning|critical", alertstate="firing"} == 1
     labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 6 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.yaml
@@ -8,10 +8,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "k8s.rules" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "k8s.rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/ks-apiserver.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/ks-apiserver.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: ks-apiserver
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "ks-apiserver" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/ks-controller-manager.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/ks-controller-manager.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: ks-controller-manager
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "ks-controller-manager" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-availability.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-availability.rules.yaml
@@ -8,10 +8,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "kube-apiserver-availability.rules" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kube-apiserver-availability.rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-burnrate.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-burnrate.rules.yaml
@@ -8,10 +8,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "kube-apiserver-burnrate.rules" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kube-apiserver-burnrate.rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-histogram.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-histogram.rules.yaml
@@ -8,10 +8,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "kube-apiserver-histogram.rules" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kube-apiserver-histogram.rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-slos.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-slos.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kube-apiserver-slos
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kube-apiserver-slos" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-state-metrics.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-state-metrics.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kube-state-metrics
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kube-state-metrics" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubelet.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubelet.rules.yaml
@@ -8,10 +8,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "kubelet.rules" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubelet.rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
@@ -9,7 +9,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kubernetes-apps
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-apps" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-resources.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-resources.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kubernetes-resources
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-resources" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kubernetes-storage
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-storage" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-apiserver.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-apiserver.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kubernetes-system-apiserver
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-system-apiserver" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-controller-manager.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-controller-manager.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kubernetes-system-controller-manager
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-system-controller-manager" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-kubelet.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-kubelet.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kubernetes-system-kubelet
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-system-kubelet" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-scheduler.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-scheduler.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kubernetes-system-scheduler
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-system-scheduler" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kubernetes-system
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-system" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubesphere-system.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubesphere-system.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: kubesphere-system
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubesphere-system" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/namespace.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/namespace.rules.yaml
@@ -8,10 +8,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "namespace.rules" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "namespace.rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: node-exporter
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "node-exporter" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-network.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-network.yaml
@@ -8,7 +8,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: node-network
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "node-network" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node.rules.yaml
@@ -8,10 +8,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "node.rules" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "node.rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus-operator.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus-operator.yaml
@@ -10,7 +10,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-operator
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "prometheus-operator" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus.rules.yaml
@@ -10,10 +10,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "prometheus.rules" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "prometheus.rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus.yaml
@@ -10,7 +10,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "prometheus" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/scheduler.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/scheduler.rules.yaml
@@ -8,10 +8,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "scheduler.rules" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "scheduler.rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/scheduler_histogram.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/scheduler_histogram.rules.yaml
@@ -8,10 +8,17 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ print "scheduler_histogram.rules" | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "scheduler_histogram.rules" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- end }}
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.defaultRules.labels }}
 {{ toYaml .Values.defaultRules.labels | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/thanos-rule.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/thanos-rule.yaml
@@ -9,7 +9,11 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 apiVersion: alerting.kubesphere.io/v2beta1
 kind: GlobalRuleGroup
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: thanos-rule
+  {{- else }}
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "thanos-rule" | trunc 63 | trimSuffix "-" }}
+  {{- end }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}
     alerting.kubesphere.io/builtin: "true"

--- a/charts/kube-prometheus-stack/templates/prometheus/service.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/service.yaml
@@ -2,10 +2,18 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- end }}
     self-monitor: {{ .Values.prometheus.serviceMonitor.selfMonitor | quote }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.prometheus.service.labels }}
@@ -56,7 +64,11 @@ spec:
   publishNotReadyAddresses: {{ .Values.prometheus.service.publishNotReadyAddresses }}
   selector:
     app.kubernetes.io/name: prometheus
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- else }}
     prometheus: {{ template "kube-prometheus-stack.prometheus.crname" . }}
+    {{- end }}
 {{- if .Values.prometheus.service.sessionAffinity }}
   sessionAffinity: {{ .Values.prometheus.service.sessionAffinity }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecar.yaml
@@ -2,10 +2,18 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}-thanos-discovery
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-thanos-discovery
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    name: prometheus-{{ include "prometheus.heritageName" . }}-thanos-discovery
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-thanos-discovery
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.prometheus.thanosService.labels }}
 {{ toYaml .Values.prometheus.thanosService.labels | indent 4 }}
@@ -35,5 +43,9 @@ spec:
     {{- end }}
   selector:
     app.kubernetes.io/name: prometheus
+    {{- if .Values.heritageNameOverride }}
+    prometheus: {{ include "prometheus.heritageName" . }}
+    {{- else }}
     prometheus: {{ template "kube-prometheus-stack.prometheus.crname" . }}
+    {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecarExternal.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecarExternal.yaml
@@ -2,7 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}-thanos-external
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-thanos-external
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
@@ -42,5 +46,9 @@ spec:
     {{- end }}
   selector:
     app.kubernetes.io/name: prometheus
+    {{- if .Values.heritageNameOverride }}
+    promethesu: {{ include "prometheus.heritageName" . }}
+    {{- else }}
     prometheus: {{ template "kube-prometheus-stack.prometheus.crname" . }}
+    {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceaccount.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceaccount.yaml
@@ -2,11 +2,20 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.prometheus.serviceAccountName" . }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}
+    app.kubernetes.io/name: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
     app.kubernetes.io/name: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- end }}
     app.kubernetes.io/component: prometheus
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.prometheus.serviceAccount.annotations }}

--- a/charts/kube-prometheus-stack/templates/prometheus/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/servicemonitor.yaml
@@ -2,16 +2,28 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- include "kubesphere-monitor.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
+      {{- if .Values.heritageNameOverride }}
+      app: prometheus-{{ include "prometheus.heritageName" . }}
+      {{- else }}
       app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+      {{- end }}
       release: {{ $.Release.Name | quote }}
       self-monitor: "true"
   namespaceSelector:

--- a/charts/kube-prometheus-stack/templates/prometheus/servicemonitorThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/servicemonitorThanosSidecar.yaml
@@ -2,15 +2,27 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}-thanos-sidecar
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-thanos-sidecar
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: prometheus-{{ include "prometheus.heritageName" . }}-thanos-sidecar
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-thanos-sidecar
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
+      {{- if .Values.heritageNameOverride }}
+      app: prometheus-{{ include "prometheus.heritageName" . }}-thanos-discovery
+      {{- else }}
       app: {{ template "kube-prometheus-stack.name" . }}-thanos-discovery
+      {{- end }}
       release: {{ $.Release.Name | quote }}
   namespaceSelector:
     matchNames:

--- a/charts/kube-prometheus-stack/templates/prometheus/servicemonitors.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/servicemonitors.yaml
@@ -9,7 +9,11 @@ items:
       name: {{ .name }}
       namespace: {{ template "kube-prometheus-stack.namespace" $ }}
       labels:
+        {{- if $.Values.heritageNameOverride }}
+        app: prometheus-{{ include "prometheus.heritageName" $ }}
+        {{- else }}
         app: {{ template "kube-prometheus-stack.name" $ }}-prometheus
+        {{- end }}
 {{ include "kube-prometheus-stack.labels" $ | indent 8 }}
         {{- if .additionalLabels }}
 {{ toYaml .additionalLabels | indent 8 }}
@@ -27,7 +31,11 @@ items:
       selector:
 {{- if .selfMonitor }}
         matchLabels:
+          {{- if $.Values.heritageNameOverride }}
+          app: prometheus-{{ include "prometheus.heritageName" . }}
+          {{- else }}
           app: {{ template "kube-prometheus-stack.name" $ }}-prometheus
+          {{- end }}
           release: {{ $.Release.Name | quote }}
           self-monitor: "true"
 {{- else }}

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceperreplica.yaml
@@ -4,17 +4,29 @@
 apiVersion: v1
 kind: List
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: prometheus-{{ include "prometheus.heritageName" . }}-serviceperreplica
+  {{- else }}
   name: {{ include "kube-prometheus-stack.fullname" $ }}-prometheus-serviceperreplica
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 items:
 {{- range $i, $e := until $count }}
   - apiVersion: v1
     kind: Service
     metadata:
+      {{- if .Values.heritageNameOverride }}
+      name: prometheus-{{ include "prometheus.heritageName" . }}-{{ $i }}
+      {{- else }}
       name: {{ include "kube-prometheus-stack.fullname" $ }}-prometheus-{{ $i }}
+      {{- end }}
       namespace: {{ template "kube-prometheus-stack.namespace" $ }}
       labels:
+        {{- if .Values.heritageNameOverride }}
+        app: prometheus-{{ include "prometheus.heritageName" . }}
+        {{- else }}
         app: {{ include "kube-prometheus-stack.name" $ }}-prometheus
+        {{- end }}
 {{ include "kube-prometheus-stack.labels" $ | indent 8 }}
       {{- if $serviceValues.annotations }}
       annotations:
@@ -42,8 +54,13 @@ items:
           targetPort: {{ $serviceValues.targetPort }}
       selector:
         app.kubernetes.io/name: prometheus
+        {{- if .Values.heritageNameOverride }}
+        prometheus: {{ include "prometheus.heritageName" $ }}
+        statefulset.kubernetes.io/pod-name: prometheus-{{ include "prometheus.heritageName" $ }}-{{ $i }}
+        {{- else }}
         prometheus: {{ include "kube-prometheus-stack.prometheus.crname" $ }}
         statefulset.kubernetes.io/pod-name: prometheus-{{ include "kube-prometheus-stack.prometheus.crname" $ }}-{{ $i }}
+        {{- end }}
       type: "{{ $serviceValues.type }}"
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/extrasecret.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/extrasecret.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.thanosRuler.extraSecret.data -}}
 {{- $secretName := printf "thanos-ruler-%s-extra" (include "kube-prometheus-stack.fullname" . ) -}}
+{{- if .Values.heritageNameOverride }}
+{{- $secretName = printf "thanos-ruler-%s-extra" (include "thanos-ruler.heritageName" . ) -}}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,7 +13,11 @@ metadata:
 {{ toYaml .Values.thanosRuler.extraSecret.annotations | indent 4 }}
 {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: thanos-ruler-{{ include "thanos-ruler.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
+    {{- end }}
     app.kubernetes.io/component: thanos-ruler
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 data:

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/ingress.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/ingress.yaml
@@ -9,14 +9,22 @@
 apiVersion: {{ include "kube-prometheus-stack.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: thanos-ruler-{{ include "thanos-ruler.heritageName" . }}
+  {{- else }}
   name: {{ $serviceName }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 {{- if .Values.thanosRuler.ingress.annotations }}
   annotations:
 {{ toYaml .Values.thanosRuler.ingress.annotations | indent 4 }}
 {{- end }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: thanos-ruler-{{ include "thanos-ruler.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
+    {{- end }}
 {{- if .Values.thanosRuler.ingress.labels }}
 {{ toYaml .Values.thanosRuler.ingress.labels | indent 4 }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/podDisruptionBudget.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/podDisruptionBudget.yaml
@@ -2,10 +2,18 @@
 apiVersion: {{ include "kube-prometheus-stack.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: thanos-ruler-{{ include "thanos-ruler.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: thanos-ruler-{{ include "thanos-ruler.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   {{- if .Values.thanosRuler.podDisruptionBudget.minAvailable }}
@@ -17,5 +25,9 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: thanos-ruler
-      thanos-ruler: {{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler
+      {{- if .Values.heritageNameOverride }}
+      app: thanos-ruler-{{ include "thanos-ruler.heritageName" . }}
+      {{- else }}
+      app: {{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler
+      {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
@@ -2,10 +2,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ThanosRuler
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: {{ include "thanos-ruler.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: thanos-ruler-{{ include "thanos-ruler.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.thanosRuler.annotations }}
   annotations:
@@ -29,13 +37,21 @@ spec:
 {{- end }}
   replicas: {{ .Values.thanosRuler.thanosRulerSpec.replicas }}
   listenLocal: {{ .Values.thanosRuler.thanosRulerSpec.listenLocal }}
+  {{- if .Values.heritageNameOverride }}
+  serviceAccountName: thanos-ruler-{{ include "thanos-ruler.heritageName" . }}
+  {{- else }}
   serviceAccountName: {{ template "kube-prometheus-stack.thanosRuler.serviceAccountName" . }}
+  {{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.externalPrefix }}
   externalPrefix: "{{ tpl .Values.thanosRuler.thanosRulerSpec.externalPrefix . }}"
 {{- else if and .Values.thanosRuler.ingress.enabled .Values.thanosRuler.ingress.hosts }}
   externalPrefix: "http://{{ tpl (index .Values.thanosRuler.ingress.hosts 0) . }}{{ .Values.thanosRuler.thanosRulerSpec.routePrefix }}"
 {{- else }}
+  {{- if .Values.heritageNameOverride }}
+  externalPrefix: http://thanos-ruler-{{ include "thanos-ruler.heritageName" . }}.{{ template "kube-prometheus-stack.namespace" . }}:{{ .Values.thanosRuler.service.port }}
+  {{- else }}
   externalPrefix: http://{{ template "kube-prometheus-stack.fullname" . }}-thanosRuler.{{ template "kube-prometheus-stack.namespace" . }}:{{ .Values.thanosRuler.service.port }}
+  {{- end }}
 {{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.nodeSelector }}
   nodeSelector:
@@ -69,7 +85,7 @@ spec:
 {{- end}}
 {{- if .Values.thanosRuler.thanosRulerSpec.alertmanagersUrl }}
   alertmanagersUrl:
-{{ toYaml .Values.thanosRuler.thanosRulerSpec.alertmanagersUrl | indent 4 }}
+{{ tpl (toYaml .Values.thanosRuler.thanosRulerSpec.alertmanagersUrl) . | indent 4 }}
 {{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.alertmanagersConfig }}
   alertmanagersConfig:
@@ -77,7 +93,7 @@ spec:
 {{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.queryEndpoints }}
   queryEndpoints:
-{{ toYaml .Values.thanosRuler.thanosRulerSpec.queryEndpoints | indent 4 }}
+{{ tpl (toYaml .Values.thanosRuler.thanosRulerSpec.queryEndpoints) . | indent 4 }}
 {{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.queryConfig }}
   queryConfig:
@@ -126,7 +142,11 @@ spec:
         labelSelector:
           matchExpressions:
             - {key: app.kubernetes.io/name, operator: In, values: [thanos-ruler]}
+            {{- if .Values.heritageNameOverride }}
+            - {key: thanos-ruler, operator: In, values: [thanos-ruler-{{ include "thanos-ruler.heritageName" . }}]}
+            {{- else }}
             - {key: thanos-ruler, operator: In, values: [{{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler]}
+            {{- end }}
 {{- else if eq .Values.thanosRuler.thanosRulerSpec.podAntiAffinity "soft" }}
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -136,7 +156,11 @@ spec:
           labelSelector:
             matchExpressions:
               - {key: app.kubernetes.io/name, operator: In, values: [thanos-ruler]}
+              {{- if .Values.heritageNameOverride }}
+              - {key: thanos-ruler, operator: In, values: [thanos-ruler-{{ include "thanos-ruler.heritageName" . }}]}
+              {{- else }}
               - {key: thanos-ruler, operator: In, values: [{{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler]}
+              {{- end }}
 {{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.tolerations }}
   tolerations:
@@ -152,7 +176,7 @@ spec:
 {{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.containers }}
   containers:
-{{ toYaml .Values.thanosRuler.thanosRulerSpec.containers | indent 4 }}
+{{ tpl (toYaml .Values.thanosRuler.thanosRulerSpec.containers) . | indent 4 }}
 {{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.initContainers }}
   initContainers:

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/service.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/service.yaml
@@ -2,10 +2,18 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: thanos-ruler-{{ include "thanos-ruler.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: thanos-ruler-{{ include "thanos-ruler.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
+    {{- end }}
     self-monitor: {{ .Values.thanosRuler.serviceMonitor.selfMonitor | quote }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.thanosRuler.service.labels }}
@@ -48,7 +56,11 @@ spec:
 {{- end }}
   selector:
     app.kubernetes.io/name: thanos-ruler
-    thanos-ruler: {{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler
+    {{- if .Values.heritageNameOverride }}
+    app: thanos-ruler-{{ include "thanos-ruler.heritageName" . }}
+    {{- else }}
+    app: {{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler
+    {{- end }}
   type: "{{ .Values.thanosRuler.service.type }}"
   sessionAffinity: "{{ .Values.thanosRuler.service.sessionAffinity }}"
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/serviceaccount.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/serviceaccount.yaml
@@ -2,11 +2,20 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: thanos-ruler-{{ include "thanos-ruler.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.thanosRuler.serviceAccountName" . }}
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: thanos-ruler-{{ include "thanos-ruler.heritageName" . }}
+    app.kubernetes.io/name: {{ include "thanos-ruler.heritageName" . }}-thanos-ruler
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
     app.kubernetes.io/name: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
+    {{- end }}
     app.kubernetes.io/component: thanos-ruler
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.thanosRuler.serviceAccount.annotations }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/servicemonitor.yaml
@@ -2,16 +2,28 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  {{- if .Values.heritageNameOverride }}
+  name: thanos-ruler-{{ include "thanos-ruler.heritageName" . }}
+  {{- else }}
   name: {{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler
+  {{- end }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
+    {{- if .Values.heritageNameOverride }}
+    app: thanos-ruler-{{ include "thanos-ruler.heritageName" . }}
+    {{- else }}
     app: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
+    {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- include "kubesphere-monitor.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
+      {{- if .Values.heritageNameOverride }}
+      app: thanos-ruler-{{ include "thanos-ruler.heritageName" . }}
+      {{- else }}
       app: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
+      {{- end }}
       release: {{ $.Release.Name | quote }}
       self-monitor: {{ .Values.thanosRuler.serviceMonitor.selfMonitor | quote }}
   namespaceSelector:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -20,7 +20,11 @@ kubeVersionOverride: ""
 
 ## Provide a name to substitute for the full names of resources
 ##
-fullnameOverride: "kubesphere"
+fullnameOverride: ""
+
+## Whether to override the resources names with those in KubeSphere 3.x
+##
+heritageNameOverride: true
 
 ## Labels to apply to all resources
 ##
@@ -48,7 +52,7 @@ defaultRules:
     kubeApiserverSlos: true
     kubeControllerManager: true
     kubelet: true
-    kubeProxy: true
+    kubeProxy: false
     kubePrometheusGeneral: true
     kubePrometheusNodeRecording: true
     kubernetesApps: true
@@ -65,7 +69,6 @@ defaultRules:
     prometheus: true
     prometheusOperator: true
     thanosRuler: true
-    
     coreDns: true
     cluster: true
     namespace: true
@@ -145,6 +148,9 @@ global:
   # - name: "image-pull-secret"
   # or
   # - "image-pull-secret"
+
+  notificationManager:
+    url: "http://notification-manager-svc.kubesphere-monitoring-system.svc:19093/api/v2/alerts"
 
 ## Configuration for alertmanager
 ## ref: https://prometheus.io/docs/alerting/alertmanager/
@@ -235,15 +241,15 @@ alertmanager:
       - name: "Watchdog"
       - name: "prometheus"
         webhook_configs:
-          - url: "http://notification-manager-svc.kubesphere-monitoring-system.svc:19093/api/v2/alerts"
+          - url: "{{ .Values.global.notificationManager.url }}"
       - name: "event"
         webhook_configs:
           - send_resolved: false
-            url: "http://notification-manager-svc.kubesphere-monitoring-system.svc:19093/api/v2/alerts"
+            url: "{{ .Values.global.notificationManager.url }}"
       - name: "auditing"
         webhook_configs:
           - send_resolved: false
-            url: "http://notification-manager-svc.kubesphere-monitoring-system.svc:19093/api/v2/alerts"
+            url: "{{ .Values.global.notificationManager.url }}"
     templates:
     - '/etc/alertmanager/config/*.tmpl'
 
@@ -255,7 +261,7 @@ alertmanager:
   ##      https://prometheus.io/docs/alerting/configuration/#tmpl_string
   ##      https://prometheus.io/docs/alerting/notifications/
   ##      https://prometheus.io/docs/alerting/notification_examples/
-  tplConfig: false
+  tplConfig: true
 
   ## Alertmanager template files to format alerts
   ## By default, templateFiles are placed in /etc/alertmanager/config/ and if
@@ -582,7 +588,7 @@ alertmanager:
 
     ## Size is the expected size of the alertmanager cluster. The controller will eventually make the size of the
     ## running cluster equal to the expected size.
-    replicas: 3
+    replicas: 1
 
     ## Time duration Alertmanager shall retain data for. Default is '120h', and must match the regular expression
     ## [0-9]+(ms|s|m|h) (milliseconds seconds minutes hours).
@@ -758,7 +764,7 @@ alertmanager:
 ## Using default values from https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
 ##
 grafana:
-  enabled: true
+  enabled: false
   namespaceOverride: ""
 
   ## ForceDeployDatasources Create datasource configmap even if grafana deployment has been disabled
@@ -1250,8 +1256,8 @@ kubeControllerManager:
     ## If null or unset, the value is determined dynamically based on target Kubernetes version due to change
     ## of default port in Kubernetes 1.22.
     ##
-    port: null
-    targetPort: null
+    port: 10257
+    targetPort: 10257
     # selector:
     #   component: kube-controller-manager
 
@@ -1269,10 +1275,10 @@ kubeControllerManager:
     ## Requires proper certs (not self-signed) and delegated authentication/authorization checks.
     ## If null or unset, the value is determined dynamically based on target Kubernetes version.
     ##
-    https: null
+    https: true
 
     # Skip TLS certificate validation when scraping
-    insecureSkipVerify: null
+    insecureSkipVerify: true
 
     # Name of the server to use when validating TLS certificate
     serverName: null
@@ -1310,6 +1316,7 @@ kubeControllerManager:
 coreDns:
   enabled: true
   service:
+    create: false
     port: 9153
     targetPort: 9153
     # selector:
@@ -1506,8 +1513,8 @@ kubeScheduler:
     ## If null or unset, the value is determined dynamically based on target Kubernetes version due to change
     ## of default port in Kubernetes 1.23.
     ##
-    port: null
-    targetPort: null
+    port: 10259
+    targetPort: 10259
     # selector:
     #   component: kube-scheduler
 
@@ -1523,10 +1530,10 @@ kubeScheduler:
     ## Requires proper certs (not self-signed) and delegated authentication/authorization checks.
     ## If null or unset, the value is determined dynamically based on target Kubernetes version.
     ##
-    https: null
+    https: true
 
     ## Skip TLS certificate validation when scraping
-    insecureSkipVerify: null
+    insecureSkipVerify: true
 
     ## Name of the server to use when validating TLS certificate
     serverName: null
@@ -1562,7 +1569,7 @@ kubeScheduler:
 ## Component scraping kube proxy
 ##
 kubeProxy:
-  enabled: true
+  enabled: false
 
   ## If your kube proxy is not deployed as a pod, specify IPs it can be found on
   ##
@@ -1623,6 +1630,8 @@ kubeStateMetrics:
 ##
 kube-state-metrics:
   namespaceOverride: ""
+  nameOverride: "kube-state-metrics"
+  fullnameOverride: "kube-state-metrics"
   image:
     repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
     tag: v2.6.0
@@ -1792,6 +1801,8 @@ nodeExporter:
 ##
 prometheus-node-exporter:
   namespaceOverride: ""
+  nameOverride: "node-exporter"
+  fullnameOverride: "node-exporter"
   podLabels:
     ## Add the 'node-exporter' label to be used by serviceMonitor to match standard common usage in rules and grafana dashboards
     ##
@@ -1805,6 +1816,7 @@ prometheus-node-exporter:
     - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$
   service:
     portName: http-metrics
+    listenOnAllInterfaces: false
   resources:
     limits:
       cpu: 250m
@@ -1819,6 +1831,8 @@ prometheus-node-exporter:
           - matchExpressions:
               - key: node-role.kubernetes.io/edge
                 operator: DoesNotExist
+  kubeRBACProxy:
+    enabled: true
 
   prometheus:
     monitor:
@@ -1827,7 +1841,7 @@ prometheus-node-exporter:
       additionalLabels:
         app.kubernetes.io/vendor: kubesphere
 
-      scheme: http
+      scheme: https
 
       bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
@@ -2075,7 +2089,7 @@ prometheusOperator:
     enabled: true
     namespace: kube-system
     ## Use '{{ template "kube-prometheus-stack.fullname" . }}-kubelet' by default
-    name: ""
+    name: "kubelet"
 
   ## Create a servicemonitor for the operator
   ##
@@ -2756,7 +2770,7 @@ prometheus:
     ## with the new list of secrets.
     ##
     secrets:
-      - kube-etcd-client-certs
+      # - kube-etcd-client-certs ## be added when enable kubeEtcd servicemonitor with tls config
 
     ## ConfigMaps is a list of ConfigMaps in the same namespace as the Prometheus object, which shall be mounted into the Prometheus Pods.
     ## The ConfigMaps are mounted into /etc/prometheus/configmaps/.
@@ -2783,7 +2797,7 @@ prometheus:
     ## PrometheusRules to be selected for target discovery.
     ## If {}, select all PrometheusRules
     ##
-    ruleSelector: {}
+    ruleSelector:
     ## Example which select all PrometheusRules resources
     ## with label "prometheus" with values any of "example-rules" or "example-rules-2"
     # ruleSelector:
@@ -2864,7 +2878,7 @@ prometheus:
 
     ## How long to retain metrics
     ##
-    retention: 10d
+    retention: 7d
 
     ## Maximum size of metrics
     ##
@@ -2881,7 +2895,7 @@ prometheus:
     ## Number of replicas of each shard to deploy for a Prometheus deployment.
     ## Number of replicas multiplied by shards is the total number of Pods created.
     ##
-    replicas: 2
+    replicas: 1
 
     ## EXPERIMENTAL: Number of shards to distribute targets onto.
     ## Number of replicas multiplied by shards is the total number of Pods created.
@@ -2976,17 +2990,12 @@ prometheus:
     ## Prometheus StorageSpec for persistent data
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/storage.md
     ##
-    storageSpec: {}
-    ## Using PersistentVolumeClaim
-    ##
-    #  volumeClaimTemplate:
-    #    spec:
-    #      storageClassName: gluster
-    #      accessModes: ["ReadWriteOnce"]
-    #      resources:
-    #        requests:
-    #          storage: 50Gi
-    #    selector: {}
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          resources:
+            requests:
+              storage: 20Gi
 
     ## Using tmpfs volume
     ##
@@ -3242,11 +3251,11 @@ prometheus:
     # When hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet automatically.
     hostNetwork: false
 
-  additionalRulesForClusterRole: []
-  #  - apiGroups: [ "" ]
-  #    resources:
-  #      - nodes/proxy
-  #    verbs: [ "get", "list", "watch" ]
+  additionalRulesForClusterRole:
+  - apiGroups: [""]
+    resources:
+    - services/node-exporter
+    verbs: ["get"]
 
   additionalServiceMonitors:
   - name: "reload-web"
@@ -3535,13 +3544,7 @@ thanosRuler:
     ## Standard object's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
     ## Metadata Labels and Annotations gets propagated to the ThanosRuler pods.
     ##
-    podMetadata:
-      labels:
-        app.kubernetes.io/component: thanos-ruler
-        app.kubernetes.io/instance: kubesphere
-        app.kubernetes.io/name: thanos-ruler
-        app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 0.29.0
+    podMetadata: {}
 
     ## Image of ThanosRuler
     ##
@@ -3599,7 +3602,7 @@ thanosRuler:
 
     ## Size is the expected size of the thanosRuler cluster. The controller will eventually make the size of the
     ## running cluster equal to the expected size.
-    replicas: 2
+    replicas: 1
 
     ## Time duration ThanosRuler shall retain data for. Default is '24h', and must match the regular expression
     ## [0-9]+(ms|s|m|h) (milliseconds seconds minutes hours).
@@ -3639,7 +3642,7 @@ thanosRuler:
     ## DEPRECATED. Define URLs to send alerts to Alertmanager. For Thanos v0.10.0 and higher, alertmanagersConfig should be used instead.
     ## Note: this field will be ignored if alertmanagersConfig is specified. Maps to the alertmanagers.url Thanos Ruler arg.
     alertmanagersUrl:
-      - "dnssrv+http://alertmanager-operated.kubesphere-monitoring-system.svc:9093"
+      - "dnssrv+http://alertmanager-operated.{{ .Release.Namespace }}.svc:9093"
 
     ## The external URL the Thanos Ruler instances will be available under. This is necessary to generate correct URLs. This is necessary if Thanos Ruler is not served from root of a DNS name. string false
     ##
@@ -3661,7 +3664,7 @@ thanosRuler:
     ## QueryEndpoints defines Thanos querier endpoints from which to query metrics.
     ## Maps to the --query flag of thanos ruler.
     queryEndpoints:
-      - "prometheus-operated.kubesphere-monitoring-system.svc:9090"
+      - "prometheus-operated.{{ .Release.Namespace }}.svc:9090"
 
     ## Define configuration for connecting to thanos query instances. If this is defined, the queryEndpoints field will be ignored.
     ## Maps to the query.config CLI argument. Only available with thanos v0.11.0 and higher.
@@ -3768,15 +3771,26 @@ thanosRuler:
           - '--alert.label-drop=thanos_ruler_replica'
           - '--log.format=logfmt'
           - '--rule-file=/etc/thanos/rules/*/*.yaml'
-          - '--query=prometheus-operated.kubesphere-monitoring-system.svc:9090'
-          - '--alertmanagers.url=dnssrv+http://alertmanager-operated.kubesphere-monitoring-system.svc:9093'
-          - '--web.external-prefix=http://kubesphere-thanosRuler.kubesphere-monitoring-system:10902'
+          - '--query=prometheus-operated.{{ .Release.Namespace }}.svc:9090'
+          - '--alertmanagers.url=dnssrv+http://alertmanager-operated.{{ .Release.Namespace }}.svc:9093'
+          - |
+            --web.external-prefix=
+            {{- if .Values.heritageNameOverride -}}
+            http://thanos-ruler-{{ include "thanos-ruler.heritageName" . }}.{{ .Release.Namespace }}:10902
+            {{- else -}}
+            http://{{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler.{{ .Release.Namespace }}:10902'
+            {{- end }}
           - '--web.route-prefix=/'
           - |
             --remote-write.config=remote_write:
-              - url: http://prometheus-kubesphere-prometheus-0.prometheus-operated.kubesphere-monitoring-system.svc:9090/api/v1/write
-              - url: http://prometheus-kubesphere-prometheus-1.prometheus-operated.kubesphere-monitoring-system.svc:9090/api/v1/write
-
+              {{- $count := .Values.prometheus.prometheusSpec.replicas | int -}}
+              {{- range $i := until $count }}
+              {{- if $.Values.heritageNameOverride }}
+              - url: http://prometheus-{{ include "prometheus.heritageName" $ }}-{{ $i }}.prometheus-operated.{{ $.Release.Namespace }}.svc:9090/api/v1/write
+              {{- else }}
+              - url: http://prometheus-{{ template "kube-prometheus-stack.prometheus.crname" $ }}-{{ $i }}.prometheus-operated.{{ $.Release.Namespace }}.svc:9090/api/v1/write
+              {{- end }}
+              {{- end }}
     # Additional volumes on the output StatefulSet definition.
     volumes: []
 


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
- support overriding the sources names with those in kse 3.x by the `heritageNameOverride: true`
- update some configs to stay as same in kse 3.x

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

- the default values is available in single cluster mode, but multi-cluster mode requires some customization
- the grafana deploys and dashboards configuration will be updated later

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
