### PR TITLE
[prometheus-node-exporter] update host and port listen

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.21.1
+version: 4.21.2
 appVersion: 1.6.0
 home: https://github.com/prometheus/node_exporter/
 sources:
@@ -27,7 +27,7 @@ dependencies:
 - condition: ProcessExporter.enabled
   name: ProcessExporter
   repository: file://charts/prometheus-process-exporter
-  version: 0.5.3
+  version: 0.5.*
 - condition: CalicoExporter.enabled
   name: CalicoExporter
   repository: file://charts/calico-exporter

--- a/charts/prometheus-node-exporter/charts/prometheus-process-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/charts/prometheus-process-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for prometheus process-exporter
 name: ProcessExporter
-version: 0.5.3
+version: 0.5.4
 home: https://github.com/mumoshu/prometheus-process-exporter
 sources:
 - https://github.com/ncabatoff/process-exporter

--- a/charts/prometheus-node-exporter/charts/prometheus-process-exporter/templates/_daemonset.tpl
+++ b/charts/prometheus-node-exporter/charts/prometheus-process-exporter/templates/_daemonset.tpl
@@ -8,7 +8,7 @@
   args:
     - --procfs=/host/proc
     - --config.path=/var/process-exporter/config.yml
-    - --web.listen-address=0.0.0.0:{{ .Values.ProcessExporter.service.innerPort }}
+    - --web.listen-address=127.0.0.1:{{ .Values.ProcessExporter.service.innerPort }}
 {{- if .Values.ProcessExporter.extraArgs }}
 {{ toYaml .Values.ProcessExporter.extraArgs | indent 12 }}
 {{- end }}

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -40,7 +40,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "prometheus-node-exporter.serviceAccountName" . }}
       containers:
-        {{- $servicePort := ternary 8100 .Values.service.port .Values.kubeRBACProxy.enabled }}
+        {{- $servicePort := .Values.service.port }}
         - name: node-exporter
           image: {{ include "prometheus-node-exporter.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -184,13 +184,15 @@ spec:
             {{-  if .Values.kubeRBACProxy.extraArgs  }}
             {{- .Values.kubeRBACProxy.extraArgs | toYaml | nindent 12 }}
             {{-  end  }}
-            - --secure-listen-address=:{{ .Values.service.port}}
+            - --secure-listen-address=[$(HOST_IP)]:{{ .Values.service.port}}
             {{- if or .Values.CalicoExporter.enabled .Values.ProcessExporter.enabled }}
             - --upstream=http://127.0.0.1:{{ .Values.nginx.port }}/
             {{- else }}
             - --upstream=http://127.0.0.1:{{ $servicePort }}/
             {{- end }}
-            - --proxy-endpoints-port=8888
+            {{- if gt (int .Values.kubeRBACProxy.proxyEndpointsPort) 0 }}
+            - --proxy-endpoints-port={{ .Values.kubeRBACProxy.proxyEndpointsPort }}
+            {{- end }}
             - --config-file=/etc/kube-rbac-proxy-config/config-file.yaml
           volumeMounts:
             - name: kube-rbac-proxy-config
@@ -204,15 +206,23 @@ spec:
           ports:
             - containerPort: {{ .Values.service.port}}
               name: "http"
-            - containerPort: 8888
+          {{- if gt (int .Values.kubeRBACProxy.proxyEndpointsPort) 0 }}
+            - containerPort: {{ .Values.kubeRBACProxy.proxyEndpointsPort }}
               name: "http-healthz"
           readinessProbe:
             httpGet:
               scheme: HTTPS
-              port: 8888
+              port: {{ .Values.kubeRBACProxy.proxyEndpointsPort }}
               path: healthz
             initialDelaySeconds: 5
             timeoutSeconds: 5
+          {{- end }}
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
           {{- if .Values.kubeRBACProxy.resources }}
           resources:
           {{ toYaml .Values.kubeRBACProxy.resources | nindent 12 }}

--- a/charts/prometheus-node-exporter/templates/nginx-configmap.yaml
+++ b/charts/prometheus-node-exporter/templates/nginx-configmap.yaml
@@ -6,9 +6,9 @@ metadata:
 data:
   nginx.conf: |-
     server {
-      listen {{ .Values.nginx.port }};
+      listen 127.0.0.1:{{ .Values.nginx.port }};
       location / {
-          proxy_pass http://localhost:8100;
+          proxy_pass http://localhost:{{ .Values.service.port }};
       }
       {{- if .Values.CalicoExporter.enabled }}
       location /metrics/calico {

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -64,10 +64,13 @@ kubeRBACProxy:
   #  cpu: 10m
   #  memory: 32Mi
 
+  # If > 0, configure --proxy-endpoints-port, and enable readiness probe
+  proxyEndpointsPort: 0
+
 service:
   type: ClusterIP
-  port: 9100
-  targetPort: 9100
+  port: 19100
+  targetPort: 19100
   nodePort:
   portName: metrics
   listenOnAllInterfaces: true
@@ -475,7 +478,7 @@ nginx:
     repository: nginxinc/nginx-unprivileged
     tag: 1.24
     pullPolicy: IfNotPresent
-  port: 8102
+  port: 18102
   resources: {}
     # limits:
     #   cpu: 200m
@@ -515,9 +518,9 @@ ProcessExporter:
 
   service:
     type: ClusterIP
-    port: 9201
-    targetPort: 9201
-    innerPort: 9202
+    port: 19201
+    targetPort: 19201
+    innerPort: 19202
     nodePort:
     annotations:
       prometheus.io/scrape: "true"
@@ -657,9 +660,9 @@ CalicoExporter:
 
   service:
     type: ClusterIP
-    port: 9094
-    targetPort: 9094
-    innerPort: 9093
+    port: 19094
+    targetPort: 19094
+    innerPort: 19093
     nodePort:
     annotations:
       prometheus.io/scrape: "true"


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

when set `kubeRBACProxy.enabled=true`, listen on hostNetwork as follows:
- node-exporter: 127.0.0.1:19100 (set port by `service.port`)
- kube-rbac-proxy: [node_ip]:19100 (set port by `service.port`)
- nginx: 127.0.0.1:19091 (set port by `nginx.port`)
- process-exporter: 127.0.0.1:19202 (set port by `ProcessExporter.service.innerPort`)
- calico-exporter: 127.0.0.1:19093 (set port by `CalicoExporter.service.innerPort`)

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #41 

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
