### PR TITLE
[kube-prometheus-stack] add serveral metrics to export

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 70.5.5
+version: 70.5.6
 appVersion: v0.81.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1844,7 +1844,7 @@ kubelet:
         sourceLabels:
         - __name__
       - action: keep
-        regex: kubelet_node_name|kubelet_running_container_count|kubelet_running_pod_count|kubelet_volume_stats.*|kubelet_pleg_relist_duration_seconds_.+|kubelet_certificate_manager_.+|kubelet_server_expiration_.+|kubelet_pod_worker_.+|kubelet_runtime_operations_.+|storage_operation_.+
+        regex: kubelet_node_name|kubelet_running_containers|kubelet_running_pods|kubelet_volume_stats.*|kubelet_pleg_relist_duration_seconds_.+|kubelet_certificate_manager_.+|kubelet_server_expiration_.+|kubelet_pod_worker_.+|kubelet_runtime_operations_.+|storage_operation_.+|kubelet_evictions
         sourceLabels:
           - __name__
     # - sourceLabels: [__name__, image]
@@ -2726,7 +2726,6 @@ kube-state-metrics:
     - kube_job_(info|owner|spec_(parallelism|active_deadline_seconds)|status_.+_time)
     - kube_cronjob_(info|status_.+|spec_.+)
     - kube_persistentvolume_(info|capacity_.+)
-    - kube_persistentvolumeclaim_access_.+
     - kube_secret_(type)
     - kube_ingress_(info|path|tls)
     - kube_replicaset_(status_.+|spec_.+)
@@ -2737,6 +2736,7 @@ kube-state-metrics:
   metricLabelsAllowlist:
     - 'namespaces=[kubesphere.io/workspace]'
     - 'storageclasses=[storage.kubesphere.io/storagetype]'
+    - 'persistentvolumeclaims=[excluded-from-alerts]'
   metricAnnotationsAllowList:
     - 'namespaces=[kubesphere.io/alias-name]'
 


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

- kubelet metrics: correct `kubelet_running_container_count`->`kubelet_running_containers`, `kubelet_running_pod_count`->`kubelet_running_pods`, keep`kubelet_evictions`  used by alert rules
- kube-state-metrics metrics: export `kube_persistentvolumeclaim_access_mode`, `kube_persistentvolumeclaim_labels` with allow label `excluded-from-alerts`, to be used by alert rules


#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
